### PR TITLE
object storage: Add method for getting file size

### DIFF
--- a/pghoard/rohmu/object_storage/azure.py
+++ b/pghoard/rohmu/object_storage/azure.py
@@ -163,6 +163,14 @@ class AzureTransfer(BaseTransfer):
         except azure.common.AzureMissingResourceHttpError as ex:
             raise FileNotFoundFromStorageError(key) from ex
 
+    def get_file_size(self, key):
+        key = self.format_key_for_backend(key, remove_slash_prefix=True)
+        try:
+            blob = self.conn.get_blob_properties(self.container_name, key)
+            return blob.properties.content_length
+        except azure.common.AzureMissingResourceHttpError as ex:
+            raise FileNotFoundFromStorageError(key) from ex
+
     def store_file_from_memory(self, key, memstring, metadata=None, cache_control=None):
         if cache_control is not None:
             raise NotImplementedError("AzureTransfer: cache_control support not implemented")

--- a/pghoard/rohmu/object_storage/base.py
+++ b/pghoard/rohmu/object_storage/base.py
@@ -59,6 +59,12 @@ class BaseTransfer:
         """Returns a tuple (content-byte-string, metadata)"""
         raise NotImplementedError
 
+    def get_file_size(self, key):
+        """Returns an int indicating the size of the file in bytes"""
+        # This method isn't currently used by PGHoard itself, it is merely provided
+        # for applications that use PGHoard's object storage abstraction layer.
+        raise NotImplementedError
+
     def get_metadata_for_key(self, key):
         raise NotImplementedError
 

--- a/pghoard/rohmu/object_storage/google.py
+++ b/pghoard/rohmu/object_storage/google.py
@@ -247,6 +247,13 @@ class GoogleTransfer(BaseTransfer):
             data = self._retry_on_reset(req, req.execute)
             return data, self._metadata_for_key(clob, key)
 
+    def get_file_size(self, key):
+        key = self.format_key_for_backend(key)
+        with self._object_client(not_found=key) as clob:
+            req = clob.get(bucket=self.bucket_name, object=key)
+            obj = self._retry_on_reset(req, req.execute)
+            return int(obj["size"])
+
     def _upload(self, upload_type, local_object, key, metadata, extra_props, cache_control):
         key = self.format_key_for_backend(key)
         self.log.debug("Starting to upload %r", key)

--- a/pghoard/rohmu/object_storage/local.py
+++ b/pghoard/rohmu/object_storage/local.py
@@ -101,6 +101,12 @@ class LocalTransfer(BaseTransfer):
         metadata = self.get_contents_to_fileobj(key, bio)
         return bio.getvalue(), metadata
 
+    def get_file_size(self, key):
+        source_path = self.format_key_for_backend(key.strip("/"))
+        if not os.path.exists(source_path):
+            raise FileNotFoundFromStorageError(key)
+        return os.stat(source_path).st_size
+
     def _save_metadata(self, target_path, metadata):
         metadata_path = target_path + ".metadata"
         with open(metadata_path, "w") as fp:

--- a/pghoard/rohmu/object_storage/swift.py
+++ b/pghoard/rohmu/object_storage/swift.py
@@ -212,6 +212,11 @@ class SwiftTransfer(BaseTransfer):
         metadata = self._headers_to_metadata(headers)
         return data, metadata
 
+    def get_file_size(self, key):
+        # Not implemented due to lack of environment where to test this. This method is not required by
+        # PGHoard itself, this is only called by external apps that utilize PGHoard's object storage abstraction.
+        raise NotImplementedError
+
     def store_file_from_memory(self, key, memstring, metadata=None, cache_control=None):
         if cache_control is not None:
             raise NotImplementedError("SwiftTransfer: cache_control support not implemented")


### PR DESCRIPTION
While PGHoard itself does not currently require this method, the object
storage abstraction it provides can be used by other applications that
would benefit from having such functionality available.