### PR TITLE
RFC: object storage: refactor iteration methods to include prefixes

### DIFF
--- a/pghoard/rohmu/object_storage/azure.py
+++ b/pghoard/rohmu/object_storage/azure.py
@@ -7,7 +7,7 @@ See LICENSE for details
 # pylint: disable=import-error, no-name-in-module
 from azure.storage.blob import BlockBlobService
 from azure.storage.blob.models import BlobPrefix
-from .base import BaseTransfer
+from .base import BaseTransfer, CHILD_TYPE_PREFIX, CHILD_TYPE_OBJECT, Child
 from ..errors import FileNotFoundFromStorageError, InvalidConfigurationError, StorageError
 import azure.common
 import time
@@ -40,44 +40,46 @@ class AzureTransfer(BaseTransfer):
 
     def get_metadata_for_key(self, key):
         path = self.format_key_for_backend(key, remove_slash_prefix=True, trailing_slash=False)
-        results = list(self._list_iter(path))
-        if not results:
+        children = list(self._iter_children(path=path, with_metadata=True))
+        if not children:
             raise FileNotFoundFromStorageError(key)
-        return results[0]["metadata"]
+        child, = children
+        if child.type != CHILD_TYPE_OBJECT:
+            raise FileNotFoundFromStorageError(key)  # it's a prefix
+        return child.value["metadata"]
 
-    def _metadata_for_key(self, key):
-        return list(self._list_iter(key))[0]["metadata"]
+    def _metadata_for_key(self, path):
+        return list(self._iter_children(path=path, with_metadata=True))[0].value["metadata"]
 
-    def list_path(self, key, *, with_metadata=True):
-        # Trailing slash needed when listing directories, without when listing individual files
+    def iter_children(self, key, *, with_metadata=True):
         path = self.format_key_for_backend(key, remove_slash_prefix=True, trailing_slash=True)
-        return list(self._list_iter(path, with_metadata=with_metadata))
+        self.log.debug("Listing children of path %r", path)
+        yield from self._iter_children(path=path, with_metadata=with_metadata)
 
-    def list_iter(self, key, *, with_metadata=True):
-        # Trailing slash needed when listing directories, without when listing individual files
-        path = self.format_key_for_backend(key, remove_slash_prefix=True, trailing_slash=True)
-        yield from self._list_iter(path, with_metadata=with_metadata)
-
-    def _list_iter(self, path, *, with_metadata=True):
-        self.log.debug("Listing path %r", path)
+    def _iter_children(self, *, path, with_metadata):
         include = "metadata" if with_metadata else None
         if path:
             items = self.conn.list_blobs(self.container_name, prefix=path, delimiter="/", include=include)
         else:  # If you give Azure an empty path, it gives you an authentication error
             items = self.conn.list_blobs(self.container_name, delimiter="/", include=include)
         for item in items:
-            if not isinstance(item, BlobPrefix):
+            if isinstance(item, BlobPrefix):
+                yield Child(type=CHILD_TYPE_PREFIX, value=self.format_key_from_backend(item.name).rstrip("/"))
+            else:
                 if with_metadata:
                     # Azure Storage cannot handle '-' so we turn them into underscores and back again
-                    metadata = dict((k.replace("_", "-"), v) for k, v in item.metadata.items())
+                    metadata = {k.replace("_", "-"): v for k, v in item.metadata.items()}
                 else:
                     metadata = None
-                yield {
-                    "last_modified": item.properties.last_modified,
-                    "metadata": metadata,
-                    "name": self.format_key_from_backend(item.name),
-                    "size": item.properties.content_length,
-                }
+                yield Child(
+                    type=CHILD_TYPE_OBJECT,
+                    value={
+                        "last_modified": item.properties.last_modified,
+                        "metadata": metadata,
+                        "name": self.format_key_from_backend(item.name),
+                        "size": item.properties.content_length,
+                    },
+                )
 
     def delete_key(self, key):
         key = self.format_key_for_backend(key, remove_slash_prefix=True)

--- a/pghoard/rohmu/object_storage/base.py
+++ b/pghoard/rohmu/object_storage/base.py
@@ -4,8 +4,16 @@ rohmu - object_storage.base
 Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
+from collections import namedtuple
+
 from ..errors import StorageError
 import logging
+
+
+CHILD_TYPE_OBJECT = "object"
+CHILD_TYPE_PREFIX = "prefix"
+
+Child = namedtuple("Child", ["type", "value"])
 
 
 class BaseTransfer:
@@ -72,6 +80,19 @@ class BaseTransfer:
         return list(self.list_iter(key, with_metadata=with_metadata))
 
     def list_iter(self, key, *, with_metadata=True):
+        for child in self.iter_children(key, with_metadata=with_metadata):
+            if child.type == CHILD_TYPE_OBJECT:
+                yield child.value
+
+    def list_prefixes(self, key):
+        return list(self.iter_prefixes(key))
+
+    def iter_prefixes(self, key):
+        for child in self.iter_children(key, with_metadata=False):
+            if child.type == CHILD_TYPE_PREFIX:
+                yield child.value
+
+    def iter_children(self, key, *, with_metadata=True):
         raise NotImplementedError
 
     def sanitize_metadata(self, metadata, replace_hyphen_with="-"):

--- a/pghoard/rohmu/object_storage/swift.py
+++ b/pghoard/rohmu/object_storage/swift.py
@@ -4,7 +4,7 @@ rohmu - openstack swift object store interface
 Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
-from .base import BaseTransfer
+from .base import BaseTransfer, CHILD_TYPE_PREFIX, CHILD_TYPE_OBJECT, Child
 from ..compat import suppress
 from ..dates import parse_timestamp
 from ..errors import FileNotFoundFromStorageError
@@ -113,26 +113,30 @@ class SwiftTransfer(BaseTransfer):
 
         return metadata
 
-    def list_iter(self, key, *, with_metadata=True):
+    def iter_children(self, key, *, with_metadata=True):
         path = self.format_key_for_backend(key, trailing_slash=True)
         self.log.debug("Listing path %r", path)
         _, results = self.conn.get_container(self.container_name, prefix=path, delimiter="/", full_listing=True)
         for item in results:
             if "subdir" in item:
-                continue  # skip directory entries
-            if with_metadata:
-                metadata = self._metadata_for_key(item["name"], resolve_manifest=True)
-                segments_size = metadata.pop("_segments_size", 0)
+                yield Child(type=CHILD_TYPE_PREFIX, value=self.format_key_from_backend(item["name"]).rstrip("/"))
             else:
-                metadata = None
-                segments_size = 0
-            last_modified = parse_timestamp(item["last_modified"])
-            yield {
-                "name": self.format_key_from_backend(item["name"]),
-                "size": item["bytes"] + segments_size,
-                "last_modified": last_modified,
-                "metadata": metadata,
-            }
+                if with_metadata:
+                    metadata = self._metadata_for_key(item["name"], resolve_manifest=True)
+                    segments_size = metadata.pop("_segments_size", 0)
+                else:
+                    metadata = None
+                    segments_size = 0
+                last_modified = parse_timestamp(item["last_modified"])
+                yield Child(
+                    type=CHILD_TYPE_OBJECT,
+                    value={
+                        "name": self.format_key_from_backend(item["name"]),
+                        "size": item["bytes"] + segments_size,
+                        "last_modified": last_modified,
+                        "metadata": metadata,
+                    },
+                )
 
     def _delete_object_plain(self, key):
         try:

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -77,6 +77,8 @@ def _test_storage(st, driver, tmpdir, storage_config):
     to_disk_file = str(scratch.join("b"))
     assert st.get_contents_to_file("test1/td", to_disk_file) == {"to-disk": "42"}
 
+    created_keys = {"test1/x1", "test1/td"}
+
     if driver == "s3":
         response = st.s3_client.head_object(
             Bucket=st.bucket_name,
@@ -105,6 +107,43 @@ def _test_storage(st, driver, tmpdir, storage_config):
         else:
             assert 0, "unexpected name in directory"
 
+    assert set(st.iter_prefixes("test1")) == set()
+
+    for key in ["test1/sub1/sub1.1", "test1/sub2/sub2.1/sub2.1.1", "test1/sub3"]:
+        st.store_file_from_memory(key, b"1", None)
+        created_keys.add(key)
+
+    if driver == "local":
+        # sub3 is a directory. Actual object storage systems support this, but a file system does not
+        with pytest.raises(NotADirectoryError):
+            st.store_file_from_memory("test1/sub3/sub3.1/sub3.1.1", b"1", None)
+    else:
+        st.store_file_from_memory("test1/sub3/sub3.1/sub3.1.1", b"1", None)
+        created_keys.add("test1/sub3/sub3.1/sub3.1.1")
+
+    if driver == "local":
+        assert set(st.iter_prefixes("test1")) == {"test1/sub1", "test1/sub2"}
+    else:
+        assert set(st.iter_prefixes("test1")) == {"test1/sub1", "test1/sub2", "test1/sub3"}
+    assert {item["name"] for item in st.list_path("test1")} == {"test1/x1", "test1/td", "test1/sub3"}
+    assert set(st.iter_prefixes("test1/sub1")) == set()
+    assert {item["name"] for item in st.list_path("test1/sub1")} == {"test1/sub1/sub1.1"}
+    assert {item["name"] for item in st.list_path("test1/sub2")} == set()
+    if driver == "local":
+        with pytest.raises(NotADirectoryError):
+            st.list_path("test1/sub3")
+    else:
+        assert {item["name"] for item in st.list_path("test1/sub3")} == set()
+    assert set(st.iter_prefixes("test1/sub2")) == {"test1/sub2/sub2.1"}
+    if driver == "local":
+        with pytest.raises(NotADirectoryError):
+            set(st.iter_prefixes("test1/sub3"))
+        with pytest.raises(NotADirectoryError):
+            set(st.iter_prefixes("test1/sub3/3.1"))
+    else:
+        assert set(st.iter_prefixes("test1/sub3")) == {"test1/sub3/sub3.1"}
+        assert set(st.iter_prefixes("test1/sub3/3.1")) == set()
+
     if driver == "google":
         # test extra props for cacheControl in google
         st.store_file_from_memory("test1/x1", b"no cache test",
@@ -125,8 +164,9 @@ def _test_storage(st, driver, tmpdir, storage_config):
         os.unlink(target_file + ".metadata")
         assert st.get_metadata_for_key("test1/x1") == {}
 
-    st.delete_key("test1/x1")
-    st.delete_key("test1/td")
+    for key in created_keys:
+        st.delete_key(key)
+
     assert st.list_path("test1") == []  # empty again
 
     test_hash = hashlib.sha256()


### PR DESCRIPTION
Refactor the `list_iter` method into `iter_children` that yields both
objects (as `list_iter` does) and prefixes that are immediate children
of the given key. The yielded items are instances of `Child`, which is a
`namedtuple` with the `type` attribute set to `"object"` or `"prefix"`.
The `value` attribute is a `dict` for `"object"` type items, and an
`str` for `"prefix"` types.

`BaseTransfer.list_iter` and `BaseTransfer.iter_prefixes` filter over
`list_iter` items yielding only child values of the relevant type.

Backwards compatibility is maintained for `list_iter` and `list_path`.