### PR TITLE
RFC: object storage: refactor iteration methods to include prefixes

### DIFF
--- a/pghoard/rohmu/object_storage/google.py
+++ b/pghoard/rohmu/object_storage/google.py
@@ -47,7 +47,7 @@ except ImportError:
 
 from ..dates import parse_timestamp
 from ..errors import FileNotFoundFromStorageError, InvalidConfigurationError
-from .base import BaseTransfer
+from .base import BaseTransfer, KEY_TYPE_PREFIX, KEY_TYPE_OBJECT, IterKeyItem
 
 # Silence Google API client verbose spamming
 logging.getLogger("googleapiclient.discovery_cache").setLevel(logging.ERROR)
@@ -174,32 +174,51 @@ class GoogleTransfer(BaseTransfer):
         obj = self._retry_on_reset(req, req.execute)
         return obj.get("metadata", {})
 
-    def _unpaginate(self, domain, initial_op):
+    def _unpaginate(self, domain, initial_op, *, on_properties):
         """Iterate thru the request pages until all items have been processed"""
         request = initial_op(domain)
         while request is not None:
             result = self._retry_on_reset(request, request.execute)
-            yield from result.get("items", [])
+            for on_property in on_properties:
+                items = result.get(on_property)
+                if items is not None:
+                    yield on_property, items
             request = domain.list_next(request, result)
 
-    def list_iter(self, key, *, with_metadata=True):  # pylint: disable=unused-argument, unused-variable
-        path = self.format_key_for_backend(key, trailing_slash=True)
+    def iter_key(self, key, *, with_metadata=True,  # pylint: disable=unused-argument, unused-variable
+                 deep=False, include_key=False):
+        path = self.format_key_for_backend(key, trailing_slash=not include_key)
         self.log.debug("Listing path %r", path)
         with self._object_client() as clob:
             def initial_op(domain):
-                return domain.list(bucket=self.bucket_name, delimiter="/", prefix=path)
+                if deep:
+                    kwargs = {}
+                else:
+                    kwargs = {"delimiter": "/"}
+                return domain.list(bucket=self.bucket_name, prefix=path, **kwargs)
 
-            for item in self._unpaginate(clob, initial_op):
-                if item["name"].endswith("/"):
-                    continue  # skip directory level objects
+            for property_name, items in self._unpaginate(clob, initial_op, on_properties=["items", "prefixes"]):
+                if property_name == "items":
+                    for item in items:
+                        if item["name"].endswith("/"):
+                            self.log.warning("list_iter: directory entry %r", item)
+                            continue  # skip directory level objects
 
-                yield {
-                    "name": self.format_key_from_backend(item["name"]),
-                    "size": int(item["size"]),
-                    "last_modified": parse_timestamp(item["updated"]),
-                    "metadata": item.get("metadata", {}),
-                    "md5": base64_to_hex(item["md5Hash"]),
-                }
+                        yield IterKeyItem(
+                            type=KEY_TYPE_OBJECT,
+                            value={
+                                "name": self.format_key_from_backend(item["name"]),
+                                "size": int(item["size"]),
+                                "last_modified": parse_timestamp(item["updated"]),
+                                "metadata": item.get("metadata", {}),
+                                "md5": base64_to_hex(item["md5Hash"]),
+                            },
+                        )
+                elif property_name == "prefixes":
+                    for prefix in items:
+                        yield IterKeyItem(type=KEY_TYPE_PREFIX, value=self.format_key_from_backend(prefix).rstrip("/"))
+                else:
+                    raise NotImplementedError(property_name)
 
     def delete_key(self, key):
         key = self.format_key_for_backend(key)

--- a/pghoard/rohmu/object_storage/swift.py
+++ b/pghoard/rohmu/object_storage/swift.py
@@ -4,7 +4,7 @@ rohmu - openstack swift object store interface
 Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
-from .base import BaseTransfer
+from .base import BaseTransfer, KEY_TYPE_PREFIX, KEY_TYPE_OBJECT, IterKeyItem
 from ..compat import suppress
 from ..dates import parse_timestamp
 from ..errors import FileNotFoundFromStorageError
@@ -113,26 +113,34 @@ class SwiftTransfer(BaseTransfer):
 
         return metadata
 
-    def list_iter(self, key, *, with_metadata=True):
-        path = self.format_key_for_backend(key, trailing_slash=True)
+    def iter_key(self, key, *, with_metadata=True, deep=False, include_key=False):
+        path = self.format_key_for_backend(key, trailing_slash=not include_key)
         self.log.debug("Listing path %r", path)
-        _, results = self.conn.get_container(self.container_name, prefix=path, delimiter="/", full_listing=True)
+        if deep:
+            kwargs = {"delimiter": "/"}
+        else:
+            kwargs = {}
+        _, results = self.conn.get_container(self.container_name, prefix=path, full_listing=True, **kwargs)
         for item in results:
             if "subdir" in item:
-                continue  # skip directory entries
-            if with_metadata:
-                metadata = self._metadata_for_key(item["name"], resolve_manifest=True)
-                segments_size = metadata.pop("_segments_size", 0)
+                yield IterKeyItem(type=KEY_TYPE_PREFIX, value=self.format_key_from_backend(item["name"]).rstrip("/"))
             else:
-                metadata = None
-                segments_size = 0
-            last_modified = parse_timestamp(item["last_modified"])
-            yield {
-                "name": self.format_key_from_backend(item["name"]),
-                "size": item["bytes"] + segments_size,
-                "last_modified": last_modified,
-                "metadata": metadata,
-            }
+                if with_metadata:
+                    metadata = self._metadata_for_key(item["name"], resolve_manifest=True)
+                    segments_size = metadata.pop("_segments_size", 0)
+                else:
+                    metadata = None
+                    segments_size = 0
+                last_modified = parse_timestamp(item["last_modified"])
+                yield IterKeyItem(
+                    type=KEY_TYPE_OBJECT,
+                    value={
+                        "name": self.format_key_from_backend(item["name"]),
+                        "size": item["bytes"] + segments_size,
+                        "last_modified": last_modified,
+                        "metadata": metadata,
+                    },
+                )
 
     def _delete_object_plain(self, key):
         try:


### PR DESCRIPTION
Refactor the `list_iter` method into `iter_key` that yields both objects
(as `list_iter` does) and prefixes. For `deep=False` (the default), only
objects that are immediate children of the key are yielded, while for
objects further down the hierarchy their prefixes. For `deep=True`, all
objects with the given key prefix are yielded. Note that in this case
there are no prefix items yielded.

The yielded items are instances of `IterKeyItem` , which is a
`namedtuple` with the `type` attribute set to `"object"` or `"prefix"`.
The `value` attribute is a `dict` for `"object"` type items, and an
`str` for `"prefix"` types.

`BaseTransfer.list_iter` and `BaseTransfer.iter_prefixes` filter over
`list_iter` items yielding only child values of the relevant type.

Backwards compatibility is maintained for `list_iter` and `list_path`.