### PR TITLE
pghoard: zero time_of_last_backup_check value considered as not checked

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -432,8 +432,8 @@ class PGHoard:
                     chosen_backup_node=chosen_backup_node,
                     last_flushed_lsn=walreceiver_state.get("last_flushed_lsn"))
 
-        if site not in self.time_of_last_backup_check or \
-                time.monotonic() - self.time_of_last_backup_check[site] > 300:
+        last_check_time = self.time_of_last_backup_check.get(site)
+        if not last_check_time or (time.monotonic() - self.time_of_last_backup_check[site]) > 300:
             self.time_of_last_backup[site] = self.check_backup_count_and_state(site)
             self.time_of_last_backup_check[site] = time.monotonic()
 


### PR DESCRIPTION
Helps the test mock code trigger the expected behavior without by
setting the time_of_last_backup_check value to zero and thus avoiding
the 300 second wait.