### PR TITLE
pghoard: object storage change support

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -552,6 +552,7 @@ class PGHoard:
 
         for thread in self._get_all_threads():
             thread.config = new_config
+            thread.site_transfers = {}
 
         self.log.debug("Loaded config: %r from: %r", self.config, self.config_path)
 


### PR DESCRIPTION
When changing object storage, pghoard would have to be restarted in order to use
the new object storage. The reason for this is that the TransferAgent would never read the
new value from the config if it already had a value stored in memory. This commit clears that value
and makes sure it gets forced to load the new value from the config.