### PR TITLE
WIP: Add restore_max_stale_seconds parameter, default 120, and use it in restore.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -487,6 +487,10 @@ Determines syslog log facility. (requires syslog to be true as well)
 After this many failed upload attempts for a single file, create an
 alert file.
 
+``restore_max_stale_seconds`` (default ``120``)
+
+Wait for this delay before aborting a staled restore attempt.
+
 ``tar_executable`` (default ``"pghoard_gnutaremu"``)
 
 The tar command to use for restoring basebackups. This must be GNU tar because some

--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -47,6 +47,7 @@ def set_and_check_config_defaults(config, *, check_commands=True, check_pgdata=T
     config.setdefault("path_prefix", "")  # deprecated, used in the default path for sites
     config.setdefault("tar_executable", "pghoard_gnutaremu")
     config.setdefault("upload_retries_warning_limit", 3)
+    config.setdefault("restore_max_stale_seconds", 120)
 
     # default to cpu_count + 1 compression threads
     config.setdefault("compression", {}).setdefault(

--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -453,7 +453,6 @@ class BasebackupFetcher():
         self.last_total_downloaded = 0
         self.lock = RLock()
         self.manager_class = multiprocessing.Manager if self._process_count() > 1 else ThreadingManager
-        self.max_stale_seconds = 120
         self.pending_jobs = set()
         self.pgdata = pgdata
         # There's no point in spawning child processes if process count is 1
@@ -588,7 +587,7 @@ class BasebackupFetcher():
             self._print_download_progress()
             self.sleep_fn(1)
             stall_duration = time.monotonic() - self.last_progress_ts
-            if stall_duration > self.max_stale_seconds:
+            if stall_duration > self.config["restore_max_stale_seconds"]:
                 self.log.error("Download stalled for %r seconds, aborting downloaders", stall_duration)
                 raise TimeoutError()
 


### PR DESCRIPTION
Add timeout parameter to solve non-ability to restore from a "large" backup because of faulty TimeoutError.

I have a basebackup which is 50GB large, and restore failed because restore.py considers that the process is stalling and kills it. However, df -h showed me that it progresses.
Removing the timeout altogether made it work.

So I'm proposing a simple change to specify the timeout as a parameter.
Maybe a better, proper fix is needed for the "staled progress" error, but that is not incompatible.

Below is error log of original code:
```
Create pghoard directories...
Create pghoard configuration with confd ...
2018-11-28T13:01:18Z my_hostname confd[12]: INFO Starting confd
2018-11-28T13:01:18Z my_hostname confd[12]: INFO Backend set to env
2018-11-28T13:01:18Z my_hostname confd[12]: INFO Backend source(s) set to 
2018-11-28T13:01:18Z my_hostname confd[12]: INFO Target config /home/postgres/pghoard.json out of sync
2018-11-28T13:01:18Z my_hostname confd[12]: INFO Target config /home/postgres/pghoard.json has been updated
2018-11-28T13:01:18Z my_hostname confd[12]: INFO Target config /home/postgres/pghoard_restore.json out of sync
2018-11-28T13:01:18Z my_hostname confd[12]: INFO Target config /home/postgres/pghoard_restore.json has been updated
Dump configuration...
   "backup_sites":{
         "basebackup_count": 1024,
         "nodes":[{}],
   "backup_location": "/home/postgres/pghoard",
            "storage_type": "local",
{
      "my_backup":{
         
         "object_storage":{
         
         
   "http_port": 16000,
         },
         "pg_xlog_directory": "/home/postgres/restore/pg_xlog"
   "syslog_address": "/dev/log",
}
Set pghoard to maintenance mode
      }
   "http_address": "127.0.0.1",
   "syslog_facility": "local2"
         "pg_data_directory": "/home/postgres/restore",
   "log_level": "INFO",
            "directory": "/var/lib/pghoard"
   "syslog": false,
   },
Get the latest available basebackup ...
----------------------------------------  -----------  -----------  --------------------
my_backup/basebackup/2018-11-20_0         7 MB        38 MB  2018-11-20T10:29:23Z
    metadata: {'compression-algorithm': 'snappy', 'start-wal-segment': '00000001000000000000004E', 'pg-version': '90611', 'original-file-size': '52230144'}
    metadata: {'compression-algorithm': 'snappy', 'start-wal-segment': '000000010000000D000000AA', 'pg-version': '90611', 'original-file-size': '51697075712'}
my_backup/basebackup/2018-11-21_0         7 MB        38 MB  2018-11-21T10:29:30Z
my_backup/basebackup/2018-11-23_0         9 MB        49 MB  2018-11-23T10:29:40Z
my_backup/basebackup/2018-11-27_0     16164 MB     50015 MB  2018-11-27T13:20:16Z

Selecting 'my_backup/basebackup/2018-11-27_0' for restore
my_backup/basebackup/2018-11-25_0     16011 MB     49491 MB  2018-11-25T11:49:00Z
Found 8 applicable basebackups 

    metadata: {'compression-algorithm': 'snappy', 'start-wal-segment': '000000010000000000000004', 'pg-version': '90611', 'original-file-size': '40560128'}
    metadata: {'compression-algorithm': 'snappy', 'start-wal-segment': '000000010000000000000006', 'pg-version': '90611', 'original-file-size': '40593920'}
my_backup/basebackup/2018-11-22_0         7 MB        38 MB  2018-11-22T10:29:35Z
    metadata: {'compression-algorithm': 'snappy', 'start-wal-segment': '000000010000000000000008', 'pg-version': '90611', 'original-file-size': '40593920'}
my_backup/basebackup/2018-11-24_0     15957 MB     49302 MB  2018-11-24T11:06:43Z
    metadata: {'compression-algorithm': 'snappy', 'start-wal-segment': '000000010000000E00000057', 'pg-version': '90611', 'original-file-size': '51895871488'}
Basebackup                                Backup size    Orig size  Start time          
my_backup/basebackup/2018-11-26_0     16086 MB     49732 MB  2018-11-26T12:34:35Z
    metadata: {'compression-algorithm': 'snappy', 'start-wal-segment': '000000010000000F00000024', 'pg-version': '90611', 'original-file-size': '52148566528'}
    metadata: {'compression-algorithm': 'snappy', 'start-wal-segment': '000000010000000F000000F2', 'pg-version': '90611', 'original-file-size': '52444619776'}
/usr/local/lib/python3.5/dist-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)
2018-11-28 13:03:18,984	BasebackupFetcher	MainThread	ERROR	Download stalled for 120.26643781189341 seconds, aborting downloaders
2018-11-28 13:05:19,276	BasebackupFetcher	MainThread	ERROR	Download stalled for 120.20502231305 seconds, aborting downloaders
2018-11-28 13:07:19,598	BasebackupFetcher	MainThread	ERROR	Download stalled for 120.31026606098749 seconds, aborting downloaders

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)

Download progress: 0.00% (0 / -0 MiB)
FATAL: RestoreError: Backup download/extraction failed with 1 errors
2018-11-28 13:07:19,644	BasebackupFetcher	MainThread	ERROR	Download stalled despite retries, aborting
```