### PR TITLE
pghoard may overwrite existing basebackup when taking a new one

### DIFF
--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -100,9 +100,8 @@ class PGBaseBackup(Thread):
 
     @staticmethod
     def get_paths_for_backup(basebackup_path):
-        i = 0
         while True:
-            tsdir = datetime.datetime.utcnow().strftime("%Y-%m-%d") + "_" + str(i)
+            tsdir = datetime.datetime.utcnow().strftime("%Y-%m-%d_%H-%M")
             raw_basebackup = os.path.join(basebackup_path + "_incoming", tsdir)
             compressed_basebackup = os.path.join(basebackup_path, tsdir)
             # The backup directory names need not to be a sequence, so we lean towards skipping over any
@@ -112,7 +111,6 @@ class PGBaseBackup(Thread):
                 with suppress(FileExistsError):
                     os.makedirs(raw_basebackup)
                     return raw_basebackup, compressed_basebackup
-            i += 1
 
     def get_command_line(self, output_name):
         command = [


### PR DESCRIPTION
PGHoard generates basebackup names locally based on timestamp and a running counter.
In scenarios when basebackup are created on a new host during the same day as an earlier basebackup
was created on an older host, the old basebackup will end up overwritten and preventing recovery from that period.

Proposed change is to change the basebackup naming from %Y-%m-%d_{COUNTER} to %Y-%m-%d_%H-%M which should solve this problem.