### PR TITLE
Filter Metadata's keys from S3.

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -302,6 +302,7 @@ class PGHoard:
         for entry in results:
             # drop path from resulting list and convert timestamps
             entry["name"] = os.path.basename(entry["name"])
+            entry["metadata"] = {k.lower(): v for k, v in entry["metadata"].items()}
             entry["metadata"]["start-time"] = dates.parse_timestamp(entry["metadata"]["start-time"])
 
         results.sort(key=lambda entry: entry["metadata"]["start-time"])


### PR DESCRIPTION
Filter Metadata's keys from S3.
Minio S3 implementation return metadata with uppercase letters ( first ones ), triggering a bug in pghoard that cannot find the key ( KeyError )
This simple patch simply convert the keys of the metadata dict to lower case, solving it all . 
