### PR TITLE
rohmu: Allow setting mime type for uploaded files

### DIFF
--- a/pghoard/rohmu/object_storage/base.py
+++ b/pghoard/rohmu/object_storage/base.py
@@ -100,8 +100,8 @@ class BaseTransfer:
         return {str(k).replace("-", replace_hyphen_with): str(v)
                 for k, v in (metadata or {}).items() if v is not None}
 
-    def store_file_from_memory(self, key, memstring, metadata=None, cache_control=None):
+    def store_file_from_memory(self, key, memstring, metadata=None, cache_control=None, mimetype=None):
         raise NotImplementedError
 
-    def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None):
+    def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
         raise NotImplementedError

--- a/pghoard/rohmu/object_storage/google.py
+++ b/pghoard/rohmu/object_storage/google.py
@@ -273,10 +273,10 @@ class GoogleTransfer(BaseTransfer):
             obj = self._retry_on_reset(req, req.execute)
             return int(obj["size"])
 
-    def _upload(self, upload_type, local_object, key, metadata, extra_props, cache_control):
+    def _upload(self, upload_type, local_object, key, metadata, extra_props, cache_control, mimetype=None):
         key = self.format_key_for_backend(key)
         self.log.debug("Starting to upload %r", key)
-        upload = upload_type(local_object, mimetype="application/octet-stream",
+        upload = upload_type(local_object, mimetype=mimetype or "application/octet-stream",
                              resumable=True, chunksize=UPLOAD_CHUNK_SIZE)
         body = {"metadata": metadata}
         if extra_props:
@@ -293,15 +293,16 @@ class GoogleTransfer(BaseTransfer):
                     self.log.debug("Upload of %r to %r: %d%%", local_object, key, status.progress() * 100)
 
     def store_file_from_memory(self, key, memstring, metadata=None, extra_props=None,  # pylint: disable=arguments-differ
-                               cache_control=None):
+                               cache_control=None, mimetype=None):
         return self._upload(MediaIoBaseUpload, BytesIO(memstring), key,
-                            self.sanitize_metadata(metadata), extra_props, cache_control=cache_control)
+                            self.sanitize_metadata(metadata), extra_props,
+                            cache_control=cache_control, mimetype=mimetype)
 
     def store_file_from_disk(self, key, filepath, metadata=None,  # pylint: disable=arguments-differ, unused-variable
                              *, multipart=None, extra_props=None,  # pylint: disable=arguments-differ, unused-variable
-                             cache_control=None):
+                             cache_control=None, mimetype=None):
         return self._upload(MediaFileUpload, filepath, key, self.sanitize_metadata(metadata), extra_props,
-                            cache_control=cache_control)
+                            cache_control=cache_control, mimetype=mimetype)
 
     def get_or_create_bucket(self, bucket_name):
         """Look up the bucket if it already exists and try to create the

--- a/pghoard/rohmu/object_storage/local.py
+++ b/pghoard/rohmu/object_storage/local.py
@@ -154,14 +154,14 @@ class LocalTransfer(BaseTransfer):
         with open(metadata_path, "w") as fp:
             json.dump(self.sanitize_metadata(metadata), fp)
 
-    def store_file_from_memory(self, key, memstring, metadata=None, cache_control=None):
+    def store_file_from_memory(self, key, memstring, metadata=None, cache_control=None, mimetype=None):
         target_path = self.format_key_for_backend(key.strip("/"))
         makedirs(os.path.dirname(target_path), exist_ok=True)
         with open(target_path, "wb") as fp:
             fp.write(memstring)
         self._save_metadata(target_path, metadata)
 
-    def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None):
+    def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
         target_path = self.format_key_for_backend(key.strip("/"))
         src_stat = os.stat(filepath)
         with suppress(FileNotFoundError):

--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -193,7 +193,7 @@ class S3Transfer(BaseTransfer):
             else:
                 raise StorageError("File size lookup failed for {}".format(key)) from ex
 
-    def store_file_from_memory(self, key, memstring, metadata=None, cache_control=None):
+    def store_file_from_memory(self, key, memstring, metadata=None, cache_control=None, mimetype=None):
         key = self.format_key_for_backend(key, remove_slash_prefix=True)
         args = {
             "Bucket": self.bucket_name,
@@ -206,9 +206,11 @@ class S3Transfer(BaseTransfer):
             args["ServerSideEncryption"] = "AES256"
         if cache_control is not None:
             args["CacheControl"] = cache_control
+        if mimetype is not None:
+            args["ContentType"] = mimetype
         self.s3_client.put_object(**args)
 
-    def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None):
+    def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
         size = os.path.getsize(filepath)
         if not multipart or size <= self.multipart_chunk_size:
             with open(filepath, "rb") as fh:
@@ -236,6 +238,8 @@ class S3Transfer(BaseTransfer):
             args["ServerSideEncryption"] = "AES256"
         if cache_control is not None:
             args["CacheControl"] = cache_control
+        if mimetype is not None:
+            args["ContentType"] = mimetype
         try:
             response = self.s3_client.create_multipart_upload(**args)
         except botocore.exceptions.ClientError as ex:


### PR DESCRIPTION
When using rohmu as a standalone component being able to set mime type
for the uploaded files is sometimes relevant so allow doing so.