### PR TITLE
Filter Metadata's keys from S3.

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -302,7 +302,6 @@ class PGHoard:
         for entry in results:
             # drop path from resulting list and convert timestamps
             entry["name"] = os.path.basename(entry["name"])
-            entry["metadata"] = {k.lower(): v for k, v in entry["metadata"].items()}
             entry["metadata"]["start-time"] = dates.parse_timestamp(entry["metadata"]["start-time"])
 
         results.sort(key=lambda entry: entry["metadata"]["start-time"])

--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -111,7 +111,7 @@ class S3Transfer(BaseTransfer):
 
             for item in response.get("Contents", []):
                 if with_metadata:
-                    metadata = self._metadata_for_key(item["Key"])
+                    metadata = {k.lower(): v for k, v in self._metadata_for_key(item["Key"]).items()}
                 else:
                     metadata = None
                 name = self.format_key_from_backend(item["Key"])


### PR DESCRIPTION
Minio S3 implementation return metadata with uppercase letters ( first ones ), triggering a bug in pghoard that cannot find the key ( KeyError ).
This simple patch simply always convert the keys of the metadata dict to lower case, solving it all .
Also, my previous patch did not filtered ALL the metadata, some of the
pghoard part was working, but some execution path did not. That is why
i am removing it as it is now useless