### PR TITLE
Expose Prometheus metrics through a HTTP endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -465,6 +465,20 @@ The value is a JSON object::
 
 The ``tags`` setting can be used to enter optional tag values for the metrics.
 
+``prometheus`` (default: disabled)
+
+Expose metrics through a Prometheus endpoint.
+
+The value is a JSON object::
+
+  {
+      "tags": {
+          "<tag>": "<value>"
+      }
+  }
+
+The ``tags`` setting can be used to enter optional tag values for the metrics.
+
 ``syslog`` (default ``false``)
 
 Determines whether syslog logging should be turned on or not.

--- a/pghoard/mapping.py
+++ b/pghoard/mapping.py
@@ -1,4 +1,5 @@
 clients = {
     "statsd": ("pghoard.monitoring.statsd", "StatsClient"),
     "pushgateway": ("pghoard.monitoring.pushgateway", "PushgatewayClient"),
+    "prometheus": ("pghoard.monitoring.prometheus", "PrometheusClient"),
 }

--- a/pghoard/metrics.py
+++ b/pghoard/metrics.py
@@ -10,7 +10,7 @@ class Metrics:
         self.clients = self._init_clients(configs)
 
     def _init_clients(self, configs):
-        clients = []
+        clients = {}
 
         if not isinstance(configs, dict):
             return clients
@@ -21,21 +21,22 @@ class Metrics:
                 path, classname = map_client[k]
                 mod = __import__(path, fromlist=[classname])
                 klass = getattr(mod, classname)
-                clients.append(klass(config))
+                clients[k] = klass(config)
+
         return clients
 
     def gauge(self, metric, value, tags=None):
-        for client in self.clients:
+        for client in self.clients.values():
             client.gauge(metric, value, tags)
 
     def increase(self, metric, inc_value=1, tags=None):
-        for client in self.clients:
+        for client in self.clients.values():
             client.increase(metric, inc_value, tags)
 
     def timing(self, metric, value, tags=None):
-        for client in self.clients:
+        for client in self.clients.values():
             client.timing(metric, value, tags)
 
     def unexpected_exception(self, ex, where, tags=None):
-        for client in self.clients:
+        for client in self.clients.values():
             client.unexpected_exception(ex, where, tags)

--- a/pghoard/monitoring/prometheus.py
+++ b/pghoard/monitoring/prometheus.py
@@ -1,0 +1,39 @@
+"""
+Prometheus client (used to create a Prometheus endpoint)
+
+"""
+
+
+class PrometheusClient:
+    def __init__(self, config):
+        self._tags = config.get("tags", {})
+        self.metrics = {}
+
+    def gauge(self, metric, value, tags=None):
+        self._update(metric, value, tags)
+
+    def increase(self, metric, inc_value=1, tags=None):
+        self._update(metric, inc_value, tags)
+
+    def timing(self, metric, value, tags=None):
+        self._update(metric, value, tags)
+
+    def unexpected_exception(self, ex, where, tags=None):
+        pass
+
+    def get_metrics(self):
+        data = []
+        for metric, value in self.metrics.items():
+            line = '{} {}'.format(metric, value)
+            data.append(line)
+        return data
+
+    def _update(self, metric, value, tags):
+        metric = metric.replace(".", "_")
+        tags = {**self._tags, **tags}
+        tag_list = []
+        for k in sorted(tags.keys()):
+            tag_list.append("{}=\"{}\"".format(k, tags[k]))
+        encoded_tags = "{{{}}}".format(",".join(tag_list))
+        formatted_metric = "{}{}".format(metric, encoded_tags)
+        self.metrics[formatted_metric] = value

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -87,7 +87,8 @@ class PGHoard:
             self.config,
             self.requested_basebackup_sites,
             self.compression_queue,
-            self.transfer_queue)
+            self.transfer_queue,
+            self.metrics)
 
         for _ in range(self.config["compression"]["thread_count"]):
             compressor = CompressorThread(

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -548,7 +548,8 @@ class PGHoard:
         # Setup monitoring clients
         self.metrics = metrics.Metrics(
             statsd=self.config.get("statsd", None),
-            pushgateway=self.config.get("pushgateway", None))
+            pushgateway=self.config.get("pushgateway", None),
+            prometheus=self.config.get("prometheus", None))
 
         for thread in self._get_all_threads():
             thread.config = new_config

--- a/pghoard/webserver.py
+++ b/pghoard/webserver.py
@@ -369,7 +369,7 @@ class RequestHandler(BaseHTTPRequestHandler):
 
     def get_metrics(self, site):
         data = ""
-        if site is None:
+        if site is None and "prometheus" in self.server.metrics.clients:
             data = '\n'.join(self.server.metrics.clients["prometheus"].get_metrics())
             raise HttpResponse(data, status=200)
         else:

--- a/pghoard/webserver.py
+++ b/pghoard/webserver.py
@@ -47,13 +47,14 @@ class HttpResponse(Exception):
 
 
 class WebServer(Thread):
-    def __init__(self, config, requested_basebackup_sites, compression_queue, transfer_queue):
+    def __init__(self, config, requested_basebackup_sites, compression_queue, transfer_queue, metrics):
         super().__init__()
         self.log = logging.getLogger("WebServer")
         self.config = config
         self.requested_basebackup_sites = requested_basebackup_sites
         self.compression_queue = compression_queue
         self.transfer_queue = transfer_queue
+        self.metrics = metrics
         self.address = self.config["http_address"]
         self.port = self.config["http_port"]
         self.server = None
@@ -79,6 +80,7 @@ class WebServer(Thread):
         # aren't there.  This isn't used for explicit download requests as it's possible that a file appears
         # later on in the object store.
         self.server.prefetch_404 = deque(maxlen=32)  # pylint: disable=attribute-defined-outside-init
+        self.server.metrics = self.metrics  # pylint: disable=attribute-defined-outside-init
         self.server.serve_forever()
 
     def close(self):
@@ -152,6 +154,10 @@ class RequestHandler(BaseHTTPRequestHandler):
             if len(path) != 1:
                 raise HttpResponse("Invalid status request", status=400)
             return (None, "status", None)
+        if path[0] == "metrics":
+            if len(path) != 1:
+                raise HttpResponse("Invalid request", status=400)
+            return (None, "metrics", None)
 
         if len(path) < 2:
             raise HttpResponse("Invalid path {!r}".format(path), status=400)
@@ -361,6 +367,14 @@ class RequestHandler(BaseHTTPRequestHandler):
             # TODO: Handle site specific status
             raise HttpResponse(status=501)  # Not Implemented
 
+    def get_metrics(self, site):
+        data = ""
+        if site is None:
+            data = '\n'.join(self.server.metrics.clients["prometheus"].get_metrics())
+            raise HttpResponse(data, status=200)
+        else:
+            raise HttpResponse(status=501)  # Not Implemented
+
     def _try_save_and_verify_restored_file(self, filetype, filename, prefetch_target_path, target_path, unlink=True):
         try:
             self._save_and_verify_restored_file(filetype, filename, prefetch_target_path, target_path)
@@ -512,5 +526,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                 self.list_basebackups(site)
             elif obtype == "status":
                 self.get_status(site)
+            elif obtype == "metrics":
+                self.get_metrics(site)
             else:
                 self.get_wal_or_timeline_file(site, obname, obtype)


### PR DESCRIPTION
This PR adds an endpoint (`/metrics`) to the embedded webserver to expose Prometheus metrics.