### PR TITLE
Support delete tree, race condition fixes for local file storage

### DIFF
--- a/pghoard/rohmu/object_storage/base.py
+++ b/pghoard/rohmu/object_storage/base.py
@@ -51,6 +51,14 @@ class BaseTransfer:
     def delete_key(self, key):
         raise NotImplementedError
 
+    def delete_tree(self, key):
+        """Delete all keys under given root key. Basic implementation works by just listing all available
+        keys and deleting them individually but storage providers can implement more efficient logic."""
+        self.log.debug("Deleting tree: %r", key)
+        names = [item["name"] for item in self.list_path(key, with_metadata=False, deep=True)]
+        for name in names:
+            self.delete_key(name)
+
     def get_contents_to_file(self, key, filepath_to_store_to, *, progress_callback=None):
         """Write key contents to file pointed by `path` and return metadata.  If `progress_callback` is
         provided it must be a function which accepts two numeric arguments: current state of progress and the

--- a/pghoard/rohmu/object_storage/local.py
+++ b/pghoard/rohmu/object_storage/local.py
@@ -43,6 +43,13 @@ class LocalTransfer(BaseTransfer):
         with suppress(FileNotFoundError):
             os.unlink(metadata_path)
 
+    def delete_tree(self, key):
+        self.log.debug("Deleting tree: %r", key)
+        target_path = self.format_key_for_backend(key.strip("/"))
+        if not os.path.isdir(target_path):
+            raise FileNotFoundFromStorageError(key)
+        shutil.rmtree(target_path)
+
     def yield_item(self, file_name):
         if file_name.startswith("."):
             return

--- a/pghoard/rohmu/object_storage/local.py
+++ b/pghoard/rohmu/object_storage/local.py
@@ -8,10 +8,12 @@ from io import BytesIO
 from ..compat import makedirs, suppress
 from ..errors import FileNotFoundFromStorageError, LocalFileIsRemoteFileError
 from .base import BaseTransfer, IterKeyItem, KEY_TYPE_PREFIX, KEY_TYPE_OBJECT
+import contextlib
 import datetime
 import json
 import os
 import shutil
+import tempfile
 
 CHUNK_SIZE = 1024 * 1024
 
@@ -31,7 +33,7 @@ class LocalTransfer(BaseTransfer):
             with open(metadata_path, "r") as fp:
                 return json.load(fp)
         except FileNotFoundError:
-            return {}
+            raise FileNotFoundFromStorageError(key)
 
     def delete_key(self, key):
         self.log.debug("Deleting key: %r", key)
@@ -39,6 +41,9 @@ class LocalTransfer(BaseTransfer):
         if not os.path.exists(target_path):
             raise FileNotFoundFromStorageError(key)
         os.unlink(target_path)
+        metadata_tmp_path = target_path + ".metadata_tmp"
+        with suppress(FileNotFoundError):
+            os.unlink(metadata_tmp_path)
         metadata_path = target_path + ".metadata"
         with suppress(FileNotFoundError):
             os.unlink(metadata_path)
@@ -50,15 +55,9 @@ class LocalTransfer(BaseTransfer):
             raise FileNotFoundFromStorageError(key)
         shutil.rmtree(target_path)
 
-    def yield_item(self, file_name):
-        if file_name.startswith("."):
-            return
-        if file_name.endswith(".metadata"):
-            return
-
     @staticmethod
     def _skip_file_name(file_name):
-        return file_name.startswith(".") or file_name.endswith(".metadata")
+        return file_name.startswith(".") or file_name.endswith(".metadata") or ".metadata_tmp" in file_name
 
     @staticmethod
     def _yield_object(key, full_path, with_metadata):
@@ -107,6 +106,10 @@ class LocalTransfer(BaseTransfer):
                 else:
                     yield IterKeyItem(type=KEY_TYPE_PREFIX, value=file_key)
             else:
+                # Don't return files if metadata file is not present; files are written in two phases and
+                # should be considered available only after also metadata has been written
+                if not os.path.exists(full_path + ".metadata"):
+                    continue
                 yield from self._yield_object(
                     key=os.path.join(key.strip("/"), file_name),
                     full_path=full_path,
@@ -158,7 +161,7 @@ class LocalTransfer(BaseTransfer):
 
     def _save_metadata(self, target_path, metadata):
         metadata_path = target_path + ".metadata"
-        with open(metadata_path, "w") as fp:
+        with atomic_create_file(metadata_path) as fp:
             json.dump(self.sanitize_metadata(metadata), fp)
 
     def store_file_from_memory(self, key, memstring, metadata=None, cache_control=None, mimetype=None):
@@ -196,3 +199,20 @@ class LocalTransfer(BaseTransfer):
                     upload_progress_fn(bytes_written)
 
         self._save_metadata(target_path, metadata)
+
+
+@contextlib.contextmanager
+def atomic_create_file(file_path):
+    """Open a temporary file for writing, rename to final name when done"""
+    fd, tmp_file_path = tempfile.mkstemp(
+        prefix=os.path.basename(file_path), dir=os.path.dirname(file_path), suffix=".metadata_tmp"
+    )
+    try:
+        with os.fdopen(fd, "w") as out_file:
+            yield out_file
+
+        os.rename(tmp_file_path, file_path)
+    except Exception:  # pytest: disable=broad-except
+        with contextlib.suppress(Exception):
+            os.unlink(tmp_file_path)
+        raise

--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -104,6 +104,14 @@ class S3Transfer(BaseTransfer):
         self._metadata_for_key(key)  # check that key exists
         self.s3_client.delete_object(Bucket=self.bucket_name, Key=key)
 
+    def delete_tree(self, key):
+        key = self.format_key_for_backend(key, remove_slash_prefix=True, trailing_slash=True)
+        self.log.debug("Deleting tree: %r", key)
+        objects_to_delete = self.s3_client.list_objects(Bucket=self.bucket_name, Prefix=key)
+        delete_keys = [{"Key": key} for key in [obj["Key"] for obj in objects_to_delete.get("Contents", [])]]
+        if delete_keys:
+            self.s3_client.delete_objects(Bucket=self.bucket_name, Delete={"Objects": delete_keys})
+
     def iter_key(self, key, *, with_metadata=True, deep=False, include_key=False):
         path = self.format_key_for_backend(key, remove_slash_prefix=True, trailing_slash=not include_key)
         self.log.debug("Listing path %r", path)

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -128,7 +128,7 @@ def _test_storage(st, driver, tmpdir, storage_config):
         created_keys.add(key)
 
     if driver == "local":
-        # sub3 is a directory. Actual object storage systems support this, but a file system does not
+        # sub3 is a file. Actual object storage systems support this, but a file system does not
         with pytest.raises(NotADirectoryError):
             st.store_file_from_memory("test1/sub3/sub3.1/sub3.1.1", b"1", None)
     else:
@@ -202,8 +202,15 @@ def _test_storage(st, driver, tmpdir, storage_config):
 
     for key in created_keys:
         st.delete_key(key)
-
     assert st.list_path("test1") == []  # empty again
+
+    for name in ["test2/foo", "test2/suba/foo", "test2/subb/bar", "test2/subb/subsub/zob"]:
+        st.store_file_from_memory(name, b"somedata")
+    names = sorted(item["name"] for item in st.list_path("test2", deep=True))
+    assert names == ["test2/foo", "test2/suba/foo", "test2/subb/bar", "test2/subb/subsub/zob"]
+
+    st.delete_tree("test2")
+    assert st.list_path("test2", deep=True) == []
 
     test_hash = hashlib.sha256()
     test_file = str(scratch.join("30m"))

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -196,9 +196,10 @@ def _test_storage(st, driver, tmpdir, storage_config):
         with pytest.raises(errors.LocalFileIsRemoteFileError):
             st.get_contents_to_file("test1/x1", target_file)
 
-        # unlink metadata file, this shouldn't break anything
+        # Missing metadata is an error situation that should fail
         os.unlink(target_file + ".metadata")
-        assert st.get_metadata_for_key("test1/x1") == {}
+        with pytest.raises(errors.FileNotFoundFromStorageError):
+            st.get_metadata_for_key("test1/x1")
 
     for key in created_keys:
         st.delete_key(key)


### PR DESCRIPTION
These changes allow better emulation of cloud storages using local file storage. Previously some use cases could not be supported with local file storage and many cases did not work properly in case of concurrent access to the local storage.