### PR TITLE
File size is required in order to decrypt a basebackup with DecryptSink.

### DIFF
--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -263,8 +263,8 @@ class Restore:
             "" if len(applicable_basebackups) == 1 else "s")
         print_basebackup_list(applicable_basebackups, caption=caption)
 
-        selected = applicable_basebackups[-1]["name"]
-        print("\nSelecting {!r} for restore".format(selected))
+        selected = applicable_basebackups[-1]
+        print("\nSelecting {!r} for restore".format(selected["name"]))
         return selected
 
     def _get_basebackup(self, pgdata, basebackup, site,
@@ -296,7 +296,7 @@ class Restore:
             basebackup = self._find_nearest_basebackup()
 
         # Grab basebackup metadata to make sure it exists and to look up tablespace requirements
-        metadata = self.storage.get_basebackup_metadata(basebackup)
+        metadata = self.storage.get_basebackup_metadata(basebackup["name"])
         tablespaces = {}
 
         # Make sure we have a proper place to write the $PGDATA and possible tablespaces
@@ -318,7 +318,7 @@ class Restore:
 
         if metadata.get("format") == "pghoard-bb-v2":
             # "Backup file" is a metadata object, fetch it to get more information
-            bmeta_compressed = self.storage.get_file_bytes(basebackup)
+            bmeta_compressed = self.storage.get_file_bytes(basebackup["name"])
             with rohmufile.file_reader(fileobj=io.BytesIO(bmeta_compressed), metadata=metadata,
                                        key_lookup=config.key_lookup_for_site(self.config, site)) as input_obj:
                 bmeta = common.extract_pghoard_bb_v2_metadata(input_obj)
@@ -350,11 +350,11 @@ class Restore:
                     "path": tspath,
                 }
 
-            basebackup_data_files = [[basebackup, -1]]
+            basebackup_data_files = [[basebackup["name"], basebackup["size"]]]
 
         else:
             # Object is a raw (encrypted, compressed) basebackup
-            basebackup_data_files = [[basebackup, -1]]
+            basebackup_data_files = [[basebackup["name"], basebackup["size"]]]
 
         if tablespace_base_dir and not os.path.exists(tablespace_base_dir) and not overwrite:
             # we just care that the dir exists, but we're OK if there are other objects there

--- a/pghoard/rohmu/encryptor.py
+++ b/pghoard/rohmu/encryptor.py
@@ -358,6 +358,8 @@ class DecryptorFile(FileWrap):
 class DecryptSink(Sink):
     def __init__(self, next_sink, file_size, encryption_key_data):
         super().__init__(next_sink)
+        if file_size <= 0:
+            raise ValueError("Invalid file_size: " + str(file_size))
         self.data_bytes_received = 0
         self.data_size = file_size
         self.decryptor = Decryptor(encryption_key_data)

--- a/test/test_restore.py
+++ b/test/test_restore.py
@@ -73,7 +73,7 @@ class TestRecoveryConf(PGHoardTestCase):
         ]
 
         r.storage.list_basebackups = Mock(return_value=basebackups)
-        assert r._find_nearest_basebackup() == "2015-02-13_0"  # pylint: disable=protected-access
+        assert r._find_nearest_basebackup()["name"] == "2015-02-13_0"  # pylint: disable=protected-access
         recovery_time = datetime.datetime(2015, 2, 1)
         recovery_time = recovery_time.replace(tzinfo=datetime.timezone.utc)
         with pytest.raises(RestoreError):
@@ -81,7 +81,7 @@ class TestRecoveryConf(PGHoardTestCase):
 
         recovery_time = datetime.datetime(2015, 2, 12, 14, 20)
         recovery_time = recovery_time.replace(tzinfo=datetime.timezone.utc)
-        assert r._find_nearest_basebackup(recovery_time) == "2015-02-12_0"  # pylint: disable=protected-access
+        assert r._find_nearest_basebackup(recovery_time)["name"] == "2015-02-12_0"  # pylint: disable=protected-access
 
     def test_create_recovery_conf(self):
         td = self.temp_dir


### PR DESCRIPTION
This fixes the issue reported at https://github.com/aiven/pghoard/issues/309

The patch makes sure that the actual basebackup file size is passed to the DecryptSink, which can then decrypt the backup with no errors.