### PR TITLE
Clarify intro sentence

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ PGHoard |BuildStatus|_
 .. |BuildStatus| image:: https://travis-ci.org/aiven/pghoard.png?branch=master
 .. _BuildStatus: https://travis-ci.org/aiven/pghoard
 
-``pghoard`` is a PostgreSQL backup daemon and restore tooling for cloud object storages.
+``pghoard`` is a PostgreSQL backup daemon and restore tooling that stores backup data in cloud object stores.
 
 Features:
 


### PR DESCRIPTION
Clarify that this tooling backs up *to* cloud object stores, not that it can backup cloud object stores into pg (which only makes sense for small stores, of course).