### PR TITLE
rohmu: Add support for remote copy operation

### DIFF
--- a/pghoard/rohmu/object_storage/base.py
+++ b/pghoard/rohmu/object_storage/base.py
@@ -26,6 +26,11 @@ class BaseTransfer:
             prefix += "/"
         self.prefix = prefix
 
+    def copy_file(self, *, source_key, destination_key, metadata=None, **_kwargs):
+        """Performs remote copy from source key name to destination key name. Key must identify a file, trees
+        cannot be copied with this method. If no metadata is given copies the existing metadata."""
+        raise NotImplementedError
+
     def format_key_for_backend(self, key, remove_slash_prefix=False, trailing_slash=False):
         """Add a possible prefix to the key before sending it to the backend"""
         path = self.prefix + key

--- a/pghoard/rohmu/object_storage/google.py
+++ b/pghoard/rohmu/object_storage/google.py
@@ -164,6 +164,23 @@ class GoogleTransfer(BaseTransfer):
             retries -= 1
             time.sleep(retry_wait)
 
+    def copy_file(self, *, source_key, destination_key, metadata=None, **_kwargs):
+        source_object = self.format_key_for_backend(source_key)
+        destination_object = self.format_key_for_backend(destination_key)
+        body = {}
+        if metadata is not None:
+            body["metadata"] = metadata
+
+        with self._object_client(not_found=source_key) as clob:
+            request = clob.copy(
+                body=body,
+                destinationBucket=self.bucket_name,
+                destinationObject=destination_object,
+                sourceBucket=self.bucket_name,
+                sourceObject=source_object,
+            )
+            self._retry_on_reset(request, request.execute)
+
     def get_metadata_for_key(self, key):
         key = self.format_key_for_backend(key)
         with self._object_client(not_found=key) as clob:

--- a/pghoard/rohmu/object_storage/local.py
+++ b/pghoard/rohmu/object_storage/local.py
@@ -24,6 +24,18 @@ class LocalTransfer(BaseTransfer):
         super().__init__(prefix=prefix)
         self.log.debug("LocalTransfer initialized")
 
+    def copy_file(self, *, source_key, destination_key, metadata=None, **_kwargs):
+        source_path = self.format_key_for_backend(source_key.strip("/"))
+        destination_path = self.format_key_for_backend(destination_key.strip("/"))
+        if not os.path.isfile(source_path):
+            raise FileNotFoundFromStorageError(source_key)
+        os.makedirs(os.path.dirname(destination_path), exist_ok=True)
+        shutil.copy(source_path, destination_path)
+        if metadata is None:
+            shutil.copy(source_path + ".metadata", destination_path + ".metadata")
+        else:
+            self._save_metadata(destination_path, metadata)
+
     def get_metadata_for_key(self, key):
         source_path = self.format_key_for_backend(key.strip("/"))
         if not os.path.exists(source_path):

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -81,6 +81,12 @@ def _test_storage(st, driver, tmpdir, storage_config):
     assert st.get_contents_to_fileobj("test1/x1", out) == {"k": "v"}
     assert out.getvalue() == b"dummy"
 
+    # Copy file
+    st.copy_file(source_key="test1/x1", destination_key="test_copy/copy1")
+    assert st.get_contents_to_string("test_copy/copy1") == (b"dummy", {"k": "v"})
+    st.copy_file(source_key="test1/x1", destination_key="test_copy/copy2", metadata={"new": "meta"})
+    assert st.get_contents_to_string("test_copy/copy2") == (b"dummy", {"new": "meta"})
+
     st.store_file_from_memory("test1/x1", b"l", {"fancymetadata": "value"})
     assert st.get_contents_to_string("test1/x1") == (b"l", {"fancymetadata": "value"})
 


### PR DESCRIPTION
All storage providers support performing a remote copy operation, which
can be useful if an object has already been uploaded but another copy of
the same data is needed with different name / metadata.