### PR TITLE
Keep track of WAL SHA1 hashes to allow verifying contents

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -387,7 +387,8 @@ failures and other interruptions can cause the WAL deletion process to leave
 orphan WAL files behind, they can be deleted with this tool.
 
 ``pghoard_archive_sync`` can be used to see if any local files should
-be archived but haven't been. The other usecase it has is to determine
+be archived but haven't been or if any of the archived files have unexpected
+content and need to be archived again. The other usecase it has is to determine
 if there are any gaps in the required files in the WAL archive
 from the current WAL file on to to the latest basebackup's first WAL file.
 
@@ -441,6 +442,11 @@ configuration keys for sites are listed below.
  * ``algorithm`` default ``"snappy"`` if available, otherwise ``"lzma"``
  * ``level`` default ``"0"`` compression level for ``"lzma"`` compression
  * ``thread_count`` (default max(cpu_count, ``5``)) number of parallel compression threads
+
+``hash_algorithm`` (default ``"sha1"``)
+
+The hash algorithm used for calculating checksums for WAL or other files. Must
+be one of the algorithms supported by Python's hashlib.
 
 ``http_address`` (default ``"127.0.0.1"``)
 

--- a/pghoard/archive_sync.py
+++ b/pghoard/archive_sync.py
@@ -8,6 +8,7 @@ from . import config, logutil, version, wal
 from .rohmu.errors import InvalidConfigurationError
 from pghoard.common import get_pg_wal_directory
 import argparse
+import hashlib
 import logging
 import os
 import requests
@@ -58,13 +59,13 @@ class ArchiveSync:
         pg_version = latest_basebackup["metadata"].get("pg-version")
         return latest_basebackup["metadata"]["start-wal-segment"], pg_version
 
-    def archive_sync(self, verify, new_backup_on_failure):
-        self.check_and_upload_missing_local_files()
+    def archive_sync(self, verify, new_backup_on_failure, max_hash_checks):
+        self.check_and_upload_missing_local_files(max_hash_checks)
         if not verify:
             return None
         return self.check_wal_archive_integrity(new_backup_on_failure)
 
-    def check_and_upload_missing_local_files(self):
+    def check_and_upload_missing_local_files(self, max_hash_checks):
         current_wal_file = self.get_current_wal_file()
         first_required_wal_file, _ = self.get_first_required_wal_segment()
 
@@ -82,6 +83,7 @@ class ArchiveSync:
         wal_files = os.listdir(wal_dir)
         wal_files.sort(key=lambda f: (f.endswith(".history"), f), reverse=True)
         need_archival = []
+        hash_checks_done = 0
         for wal_file in wal_files:
             archive_type = None
             if wal.TIMELINE_RE.match(wal_file):
@@ -103,7 +105,24 @@ class ArchiveSync:
             if archive_type:
                 resp = requests.head("{base}/archive/{file}".format(base=self.base_url, file=wal_file))
                 if resp.status_code == 200:
-                    self.log.info("%s file %r already archived", archive_type, wal_file)
+                    remote_hash = resp.headers.get("metadata-hash")
+                    hash_algorithm = resp.headers.get("metadata-hash-algorithm")
+                    check_hash = bool(
+                        archive_type == "WAL" and (hash_checks_done < max_hash_checks or max_hash_checks < 0) and remote_hash
+                    )
+                    if check_hash:
+                        hash_checks_done += 1
+                        our_hash = self.calculate_hash(os.path.join(wal_dir, wal_file), hash_algorithm)
+                        if remote_hash.lower().strip() != our_hash.lower().strip():
+                            self.log.warning(
+                                "%s file %r already archived but existing hash %r differs from our hash %r, reuploading",
+                                archive_type, wal_file, remote_hash, our_hash
+                            )
+                            need_archival.append(wal_file)
+                        else:
+                            self.log.info("%s file %r already archived and has valid hash", archive_type, wal_file)
+                    else:
+                        self.log.info("%s file %r already archived", archive_type, wal_file)
                     continue
                 self.log.info("%s file %r needs to be archived", archive_type, wal_file)
                 need_archival.append(wal_file)
@@ -170,6 +189,17 @@ class ArchiveSync:
         else:
             self.log.info("Requested a new backup for site: %r successfully", self.site)
 
+    @staticmethod
+    def calculate_hash(full_name, hash_algorithm):
+        hasher = hashlib.new(hash_algorithm)
+        with open(full_name, "rb") as file_obj:
+            while True:
+                data = file_obj.read(128 * 1024)
+                if not data:
+                    break
+                hasher.update(data)
+        return hasher.hexdigest()
+
     def run(self, args=None):
         parser = argparse.ArgumentParser()
         parser.add_argument("-D", "--debug", help="Enable debug logging", action="store_true")
@@ -177,6 +207,12 @@ class ArchiveSync:
                             version=version.__version__)
         parser.add_argument("--site", help="pghoard site", required=False)
         parser.add_argument("--config", help="pghoard config file", default=os.environ.get("PGHOARD_CONFIG"))
+        # Only check hashes of files up to some threshold (unless negative value is explicitly given to indicate no
+        # limits). If there are files with invalid hashes those are typically around promotion and archive sync is
+        # usually run right after promotion so only checking some of the first files that are encountered should be
+        # enough. Checking all files could be heavy since in some cases the number of WALs could be very high.
+        hash_check_help = "Maximum number of files for which to validate hash in addition to basic existence check"
+        parser.add_argument("--max-hash-checks", help=hash_check_help, default=100)
         parser.add_argument("--no-verify", help="do not verify archive integrity", action="store_false")
         parser.add_argument("--create-new-backup-on-failure", help="request a new basebackup if verification fails",
                             action="store_true", default=False)
@@ -188,7 +224,7 @@ class ArchiveSync:
 
         logutil.configure_logging(level=logging.DEBUG if args.debug else logging.INFO)
         self.set_config(args.config, args.site)
-        return self.archive_sync(args.no_verify, args.create_new_backup_on_failure)
+        return self.archive_sync(args.no_verify, args.create_new_backup_on_failure, args.max_hash_checks)
 
 
 def main():

--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -47,6 +47,7 @@ def set_and_check_config_defaults(config, *, check_commands=True, check_pgdata=T
     config.setdefault("path_prefix", "")  # deprecated, used in the default path for sites
     config.setdefault("tar_executable", "pghoard_gnutaremu")
     config.setdefault("upload_retries_warning_limit", 3)
+    config.setdefault("hash_algorithm", "sha1")
 
     # default to cpu_count + 1 compression threads
     config.setdefault("compression", {}).setdefault(

--- a/pghoard/rohmu/rohmufile.py
+++ b/pghoard/rohmu/rohmufile.py
@@ -107,7 +107,8 @@ def file_writer(*, fileobj, compression_algorithm=None, compression_level=0, rsa
 
 def write_file(*, input_obj, output_obj, progress_callback=None,
                compression_algorithm=None, compression_level=0,
-               rsa_public_key=None, log_func=None, header_func=None):
+               rsa_public_key=None, log_func=None, header_func=None,
+               data_callback=None):
     start_time = time.monotonic()
 
     original_size = 0
@@ -121,6 +122,9 @@ def write_file(*, input_obj, output_obj, progress_callback=None,
             input_data = input_obj.read(IO_BLOCK_SIZE)
             if not input_data:
                 break
+
+            if data_callback:
+                data_callback(input_data)
 
             if header_block and header_func:
                 header_func(input_data)

--- a/pghoard/transfer.py
+++ b/pghoard/transfer.py
@@ -213,9 +213,9 @@ class TransferAgent(Thread):
     def handle_download(self, site, key, file_to_transfer):
         try:
             path = file_to_transfer["target_path"]
-            file_size = self.fetch_manager.fetch_file(site, key, path)
+            file_size, metadata = self.fetch_manager.fetch_file(site, key, path)
             file_to_transfer["file_size"] = file_size
-            return {"success": True, "opaque": file_to_transfer.get("opaque"), "target_path": path}
+            return {"success": True, "opaque": file_to_transfer.get("opaque"), "target_path": path, "metadata": metadata}
         except FileNotFoundFromStorageError as ex:
             self.log.warning("%r not found from storage", key)
             return {"success": False, "exception": ex, "opaque": file_to_transfer.get("opaque")}

--- a/pghoard/webserver.py
+++ b/pghoard/webserver.py
@@ -345,7 +345,11 @@ class RequestHandler(BaseHTTPRequestHandler):
                             self.server.log.warning("Target path for %r already exists, skipping", key)
                             continue
                         os.rename(result["target_path"], op["target_path"])
-                        self.server.log.info("Renamed %s to %s", result["target_path"], op["target_path"])
+                        metadata = result["metadata"] or {}
+                        self.server.log.info(
+                            "Renamed %s to %s. Original upload from %r, hash %s:%s", result["target_path"],
+                            op["target_path"], metadata.get("host"), metadata.get("hash-algorithm"), metadata.get("hash")
+                        )
                     else:
                         ex = result.get("exception", Error)
                         if isinstance(ex, FileNotFoundFromStorageError):

--- a/pghoard/webserver.py
+++ b/pghoard/webserver.py
@@ -518,8 +518,13 @@ class RequestHandler(BaseHTTPRequestHandler):
             site, obtype, obname = self._parse_request(path)
             if self.headers.get("x-pghoard-target-path"):
                 raise HttpResponse("x-pghoard-target-path header is only valid for downloads", status=400)
-            self._transfer_agent_op(site, obname, obtype, "METADATA")
-            raise HttpResponse(status=200)
+            response = self._transfer_agent_op(site, obname, obtype, "METADATA")
+            metadata = response["metadata"]
+            headers = {}
+            if metadata.get("hash") and metadata.get("hash-algorithm"):
+                headers["metadata-hash"] = metadata["hash"]
+                headers["metadata-hash-algorithm"] = metadata["hash-algorithm"]
+            raise HttpResponse(status=200, headers=headers)
 
     def do_GET(self):
         with self._response_handler("GET") as path:

--- a/test/test_archivesync.py
+++ b/test/test_archivesync.py
@@ -1,11 +1,13 @@
 from pghoard.common import write_json_file
 from unittest.mock import Mock, patch
+import hashlib
 import os
 import pytest
 
 
 class HTTPResult:
-    def __init__(self, result):
+    def __init__(self, result, headers=None):
+        self.headers = headers or {}
         self.status_code = result
 
 
@@ -105,3 +107,67 @@ def test_check_wal_archive_integrity(requests_put_mock, requests_head_mock, tmpd
     arsy.get_first_required_wal_segment = Mock(return_value=("000000020000000A000000FD", 90300))
     assert arsy.check_wal_archive_integrity(new_backup_on_failure=True) == 0
     assert requests_put_mock.call_count == 1
+
+
+@patch("requests.head")
+@patch("requests.put")
+def test_check_and_upload_missing_local_files(requests_put_mock, requests_head_mock, tmpdir):
+    from pghoard.archive_sync import ArchiveSync
+
+    data_dir = str(tmpdir)
+    wal_dir = os.path.join(data_dir, "pg_xlog")
+    os.makedirs(wal_dir)
+    open(os.path.join(data_dir, "PG_VERSION"), "w").write("9.6")
+
+    # Write a bunch of local files
+    file_hashes = {}
+    for index in range(32):
+        fn = "{:024X}".format(index + 1)
+        data = os.urandom(32)
+        sha1_hasher = hashlib.sha1()
+        sha1_hasher.update(data)
+        file_hashes[index + 1] = sha1_hasher.hexdigest()
+        with open(os.path.join(wal_dir, fn), "wb") as f:
+            f.write(data)
+
+    head_call_indexes = []
+    put_call_indexes = []
+
+    def requests_head(*args, **kwargs):  # pylint: disable=unused-argument
+        wal_index = int(os.path.split(args[0])[1], 16)
+        head_call_indexes.append(wal_index)
+        if wal_index > 0x14:
+            return HTTPResult(404)
+        sha1 = file_hashes[wal_index]
+        # For some files return invalid hash
+        if wal_index in {0x1, 0xb, 0xd, 0xf, 0x11, 0x13}:
+            sha1 += "invalid"
+        # For some files don't return sha1 header to test the code copes with missing header correctly
+        if wal_index in {0xf, 0x10}:
+            headers = {}
+        else:
+            headers = {"metadata-hash": sha1, "metadata-hash-algorithm": "sha1"}
+        return HTTPResult(200, headers=headers)
+
+    def requests_put(*args, **kwargs):  # pylint: disable=unused-argument
+        wal_index = int(os.path.split(args[0])[1], 16)
+        put_call_indexes.append(wal_index)
+        return HTTPResult(201)
+
+    config_file = tmpdir.join("arsy.conf").strpath
+    write_json_file(config_file, {"http_port": 8080, "backup_sites": {"foo": {"pg_data_directory": data_dir}}})
+    arsy = ArchiveSync()
+    arsy.set_config(config_file, site="foo")
+    requests_put_mock.side_effect = requests_put
+    requests_head_mock.side_effect = requests_head
+    arsy.get_current_wal_file = Mock(return_value="00000000000000000000001A")
+    arsy.get_first_required_wal_segment = Mock(return_value=("000000000000000000000001", 90300))
+
+    arsy.check_and_upload_missing_local_files(15)
+
+    assert head_call_indexes == list(reversed([index + 1 for index in range(0x19)]))
+    # Files above 0x1a in future, 0x1a is current. 0x14 and under are already uploaded but 0x13, 0x11, 0xf,
+    # 0xd, 0xb and 0x1 have invalid hash. Of those 0x1 doesn't get re-uploaded because we set max hashes to
+    # check to a value that is exceeded before reaching that and 0xf doesn't get reuploaded because remote
+    # hash for that isn't available so hash cannot be validated
+    assert put_call_indexes == [0xb, 0xd, 0x11, 0x13, 0x15, 0x16, 0x17, 0x18, 0x19]

--- a/test/test_compressor.py
+++ b/test/test_compressor.py
@@ -185,6 +185,9 @@ class CompressionCase(PGHoardTestCase):
             "site": self.test_site,
         }
         for key, value in expected.items():
+            if key == "metadata" and filetype == "xlog":
+                assert transfer_event[key].pop("hash")
+                assert transfer_event[key].pop("hash-algorithm") == "sha1"
             assert transfer_event[key] == value
 
     def test_compress_to_memory(self):
@@ -211,6 +214,9 @@ class CompressionCase(PGHoardTestCase):
         }
         transfer_event = self.transfer_queue.get(timeout=3.0)
         for key, value in expected.items():
+            if key == "metadata":
+                assert transfer_event[key].pop("hash")
+                assert transfer_event[key].pop("hash-algorithm") == "sha1"
             assert transfer_event[key] == value
 
         result = self.decompress(transfer_event["blob"])
@@ -244,6 +250,9 @@ class CompressionCase(PGHoardTestCase):
         }
         transfer_event = self.transfer_queue.get(timeout=5.0)
         for key, value in expected.items():
+            if key == "metadata":
+                assert transfer_event[key].pop("hash")
+                assert transfer_event[key].pop("hash-algorithm") == "sha1"
             assert transfer_event[key] == value
 
     def test_archive_command_compression(self):
@@ -273,6 +282,9 @@ class CompressionCase(PGHoardTestCase):
             "site": self.test_site,
         }
         for key, value in expected.items():
+            if key == "metadata":
+                assert transfer_event[key].pop("hash")
+                assert transfer_event[key].pop("hash-algorithm") == "sha1"
             assert transfer_event[key] == value
 
         assert self.decompress(transfer_event["blob"]) == zero.contents


### PR DESCRIPTION
Previously archive sync only verified file existence in remote file
storage but in some cases the files may be present but invalid. E.g.
in case old master is replaced because it became unresponsive the node
might still be running but just very slowly and it could manage to
upload WAL file for old timeline that is invalid but new master didn't
replace the file with a valid one because it was happy with the fact the
file exists even though it wasn't usable.

SHA1 was used due to its availability in Python's built-in hashlib. Some
other hashes might be more suitable due to better throughput but even
for very busy environments the performance of SHA1 should be good enough
not to cause noticeable extra load so the extra overhead of using hash
that doesn't ship with Python isn't worthwhile.

Also make archive sync reupload first file that already exists remotely
but doesn't have a checksum. When old node is running old pghoard
version and hashes are not available we cannot detect invalid WAL
files. To opt for safety, assume the latest file that has already been
uploaded is potentially invalid and reupload it. While this is almost
always not necessary the overhead of doing this is very small so it
shouldn't be an issue.