### PR TITLE
ci: run zstd tests on all platforms.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,6 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
-      install:
-        - "pip install -r requirements-zstd.txt"
-      addons:
-        apt:
-          packages:
-            - libzstd-dev
-            - libsnappy-dev
-            - postgresql-9.4
 
 install:
   - "pip install -r requirements.txt"

--- a/requirements-zstd.txt
+++ b/requirements-zstd.txt
@@ -1,2 +1,0 @@
--r requirements.txt
-zstandard

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ requests
 azure-storage
 azure
 paramiko
+zstandard


### PR DESCRIPTION
By default python-zstandard setup builds zstd binary from the sources included in repo.
"--system_zstd" build parameter controls whether to compile against the system zstd library.
For this to work, the system zstd library and headers must match what python-zstandard is coded against exactly.