### PR TITLE
rpm: disable automatic dependency generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PYTHON_SOURCE_DIRS = pghoard/ test/
 PYTEST_ARG ?= -v
 
 clean:
-	$(RM) -r *.egg-info/ build/ dist/
+	$(RM) -r *.egg-info/ build/ dist/ rpm/
 	$(RM) ../pghoard_* test-*.xml $(generated)
 
 pghoard/version.py: version.py

--- a/pghoard.spec
+++ b/pghoard.spec
@@ -21,6 +21,9 @@ Swift and Ceph (using S3 or Swift interfaces with RadosGW.)
 Support for Microsoft Azure is experimental.
 
 
+%{?python_disable_dependency_generator}
+
+
 %prep
 %setup -q -n pghoard
 


### PR DESCRIPTION
In Fedora 30 and newer dependencies are generated automically from egg/dist metadata.
We don't want that as we already specify required depedencies in .spec file.

In earlier Fedora versions automatic dependency generation was disabled by default.

https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/