### PR TITLE
receivexlog: Allow pausing xlog/WAL receiving when disk space is low

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -476,6 +476,35 @@ Determines log level of ``pghoard``.
 
 If a file exists in this location, no new backup actions will be started.
 
+``pg_receivexlog``
+
+When active backup mode is set to ``"pg_receivexlog"`` this object may
+optionally specify additional configuration options. The currently available
+options are all related to monitoring disk space availability and optionally
+pausing xlog/WAL receiving when disk space goes below configured threshold.
+This is useful when PGHoard is configured to create its temporary files on
+a different volume than where the main PostgreSQL data directory resides. By
+default this logic is disabled and the minimum free bytes must be configured
+to enable it.
+
+``pg_receivexlog.disk_space_check_interval`` (default ``10``)
+
+How often to check available disk space.
+
+``pg_receivexlog.min_disk_free_bytes`` (default undefined)
+
+Minimum bytes (as an integer) that must be available in order to keep on
+receiving xlogs/WAL from PostgreSQL. If available disk space goes below this
+limit a ``STOP`` signal is sent to the ``pg_receivexlog`` / ``pg_receivewal``
+application.
+
+``pg_receivexlog.resume_multiplier`` (default ``1.5``)
+
+Number of times the ``min_disk_free_bytes`` bytes of disk space that is
+required to start receiving xlog/WAL again (i.e. send the ``CONT`` signal to
+the ``pg_receivexlog`` / ``pg_receivewal`` process). Multiplier above 1
+should be used to avoid stopping and continuing the process constantly.
+
 ``restore_prefetch`` (default ``transfer.thread_count``)
 
 Number of files to prefetch when performing archive recovery.  The default

--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -88,6 +88,9 @@ def set_and_check_config_defaults(config, *, check_commands=True, check_pgdata=T
                                "pipe" if site_config.get("stream_compression") else "basic")
         site_config.setdefault("encryption_key_id", None)
         site_config.setdefault("object_storage", None)
+        pg_receivexlog_config = site_config.setdefault("pg_receivexlog", {})
+        pg_receivexlog_config.setdefault("disk_space_check_interval", 10.0)
+        pg_receivexlog_config.setdefault("resume_multiplier", 1.5)
         site_config.setdefault("prefix", os.path.join(config["path_prefix"], site_name))
 
         # NOTE: pg_data_directory doesn't have a default value

--- a/pghoard/receivexlog.py
+++ b/pghoard/receivexlog.py
@@ -7,7 +7,9 @@ See LICENSE for details
 
 import datetime
 import logging
+import os
 import select
+import signal
 import subprocess
 import time
 
@@ -18,14 +20,20 @@ from threading import Thread
 class PGReceiveXLog(Thread):
     def __init__(self, config, connection_string, wal_location, site, slot, pg_version_server):
         super().__init__()
+        pg_receivexlog_config = config["backup_sites"][site]["pg_receivexlog"]
         self.log = logging.getLogger("PGReceiveXLog")
         self.config = config
         self.connection_string = connection_string
+        self.disk_space_check_interval = pg_receivexlog_config["disk_space_check_interval"]
+        self.last_disk_space_check = time.monotonic()
+        self.min_disk_space = pg_receivexlog_config.get("min_disk_free_bytes")
+        self.resume_multiplier = pg_receivexlog_config["resume_multiplier"]
         self.wal_location = wal_location
         self.site = site
         self.slot = slot
         self.pg_version_server = pg_version_server
         self.pid = None
+        self.receiver_paused = False
         self.running = False
         self.latest_activity = datetime.datetime.utcnow()
         self.log.debug("Initialized PGReceiveXLog")
@@ -59,7 +67,52 @@ class PGReceiveXLog(Thread):
                     self.latest_activity = datetime.datetime.utcnow()
             if proc.poll() is not None:
                 break
+            self.stop_or_continue_based_on_free_disk()
+        self.continue_pg_receivewal()
         rc = terminate_subprocess(proc, log=self.log)
         self.log.debug("Ran: %r, took: %.3fs to run, returncode: %r",
                        command, time.time() - start_time, rc)
         self.running = False
+
+    def stop_or_continue_based_on_free_disk(self):
+        if not self.min_disk_space:
+            return
+
+        now = time.monotonic()
+        if now - self.last_disk_space_check < self.disk_space_check_interval:
+            return
+
+        bytes_free = self.get_disk_bytes_free()
+        if not self.receiver_paused:
+            if bytes_free < self.min_disk_space:
+                self.log.warning(
+                    "Free disk space %.1f MiB is below configured minimum %.1f MiB, pausing pg_receive(wal|xlog)",
+                    bytes_free / 1024.0 / 1024.0, self.min_disk_space / 1024.0 / 1024.0
+                )
+                self.pause_pg_receivewal()
+        else:
+            min_free_bytes = int(self.min_disk_space * self.resume_multiplier)
+            if bytes_free >= min_free_bytes:
+                self.log.info(
+                    "Free disk space %.1f MiB is above configured resume threshold %.1f MiB, resuming pg_receive(wal|xlog)",
+                    bytes_free / 1024.0 / 1024.0, min_free_bytes / 1024.0 / 1024.0
+                )
+                self.continue_pg_receivewal()
+
+    def get_disk_bytes_free(self):
+        st = os.statvfs(self.wal_location)
+        return st.f_bfree * st.f_bsize
+
+    def continue_pg_receivewal(self):
+        if not self.receiver_paused or not self.pid:
+            return
+
+        os.kill(self.pid, signal.SIGCONT)
+        self.receiver_paused = False
+
+    def pause_pg_receivewal(self):
+        if self.receiver_paused or not self.pid:
+            return
+
+        os.kill(self.pid, signal.SIGSTOP)
+        self.receiver_paused = True

--- a/pghoard/receivexlog.py
+++ b/pghoard/receivexlog.py
@@ -55,7 +55,7 @@ class PGReceiveXLog(Thread):
             for fd in rlist:
                 content = fd.read()
                 if content:
-                    self.log.debug(content)
+                    self.log.info(content)
                     self.latest_activity = datetime.datetime.utcnow()
             if proc.poll() is not None:
                 break


### PR DESCRIPTION
If PGHoard temporary directories reside on a different volume than the
PostgreSQL data directory itself that volume may fill up if the rate at
which new WAL files are being generated is higher than WAL processing
and upload speed. To cope with such situations, allow sending SIGSTOP
and SIGCONT to pg_receive(xlog|wal) to temporarily pause processing so
that uploads can catch up.