### PR TITLE
Allow restricting basebackups based on backup age

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -578,6 +578,12 @@ The following options control the behavior of each backup site.  A backup
 site means an individual PostgreSQL installation ("cluster" in PostgreSQL
 terminology) from which to take backups.
 
+``basebackup_age_days_max`` (default undefined)
+
+Maximum age for basebackups. Basebackups older than this will be removed. By
+default this value is not defined and basebackups are deleted based on total
+count instead.
+
 ``basebackup_chunks_in_progress`` (default ``5``)
 
 How many basebackup chunks can there be simultaneously on disk while
@@ -592,7 +598,20 @@ space needed for a successful backup is this variable multiplied by
 ``basebackup_count`` (default ``2``)
 
 How many basebackups should be kept around for restoration purposes.  The
-more there are the more diskspace will be used.
+more there are the more diskspace will be used. If ``basebackup_max_age`` is
+defined this controls the maximum number of basebackups to keep; if backup
+interval is less than 24 hour or extra backups are created there can be more
+than one basebackup per day and it is often desirable to set
+``basebackup_count`` to something slightly higher than the max age in days.
+
+``basebackup_count_min`` (default ``2``)
+
+Minimum number of basebackups to keep. This is only effective when
+``basebackup_age_days_max`` has been defined. If for example the server is
+powered off and then back on a month later, all existing backups would be very
+old. However, in that case it is usually not desirable to immediately delete
+all old backups. This setting allows specifying a minimum number of backups
+that should always be preserved regardless of their age.
 
 ``basebackup_interval_hours`` (default ``24``)
 

--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -82,6 +82,7 @@ def set_and_check_config_defaults(config, *, check_commands=True, check_pgdata=T
         site_config.setdefault("basebackup_chunk_size", 1024 * 1024 * 1024 * 2)
         site_config.setdefault("basebackup_chunks_in_progress", 5)
         site_config.setdefault("basebackup_count", 2)
+        site_config.setdefault("basebackup_count_min", 2)
         site_config.setdefault("basebackup_interval_hours", 24)
         # NOTE: stream_compression removed from documentation after 1.6.0 release
         site_config.setdefault("basebackup_mode",

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -308,6 +308,41 @@ class PGHoard:
         results.sort(key=lambda entry: entry["metadata"]["start-time"])
         return results
 
+    def determine_backups_to_delete(self, *, basebackups, site_config):
+        """Returns the basebackups in the given list that need to be deleted based on the given site configuration.
+        Note that `basebackups` is edited in place: any basebackups that need to be deleted are removed from it."""
+        allowed_basebackup_count = site_config["basebackup_count"]
+        if allowed_basebackup_count is None:
+            allowed_basebackup_count = len(basebackups)
+
+        basebackups_to_delete = []
+        while len(basebackups) > allowed_basebackup_count:
+            self.log.warning("Too many basebackups: %d > %d, %r, starting to get rid of %r",
+                             len(basebackups), allowed_basebackup_count, basebackups, basebackups[0]["name"])
+            basebackups_to_delete.append(basebackups.pop(0))
+
+        backup_interval = datetime.timedelta(hours=site_config["basebackup_interval_hours"])
+        min_backups = site_config["basebackup_count_min"]
+        max_age_days = site_config.get("basebackup_age_days_max")
+        current_time = datetime.datetime.now(datetime.timezone.utc)
+        if max_age_days and min_backups > 0:
+            while basebackups and len(basebackups) > min_backups:
+                # For age checks we treat the age as current_time - (backup_start_time + backup_interval). So when
+                # backup interval is set to 24 hours a backup started 2.5 days ago would be considered to be 1.5 days old.
+                completed_at = basebackups[0]["metadata"]["start-time"] + backup_interval
+                backup_age = current_time - completed_at
+                # timedelta would have direct `days` attribute but that's an integer rounded down. We want a float
+                # so that we can react immediately when age is too old
+                backup_age_days = backup_age.total_seconds() / 60.0 / 60.0 / 24.0
+                if backup_age_days > max_age_days:
+                    self.log.warning("Basebackup %r too old: %.3f > %.3f, %r, starting to get rid of it",
+                                     basebackups[0]["name"], backup_age_days, max_age_days, basebackups)
+                    basebackups_to_delete.append(basebackups.pop(0))
+                else:
+                    break
+
+        return basebackups_to_delete
+
     def check_backup_count_and_state(self, site):
         """Look up basebackups from the object store, prune any extra
         backups and return the datetime of the latest backup."""
@@ -319,14 +354,10 @@ class PGHoard:
         else:
             last_backup_time = None
 
-        allowed_basebackup_count = self.config["backup_sites"][site]["basebackup_count"]
-        if allowed_basebackup_count is None:
-            allowed_basebackup_count = len(basebackups)
+        site_config = self.config["backup_sites"][site]
+        basebackups_to_delete = self.determine_backups_to_delete(basebackups=basebackups, site_config=site_config)
 
-        while len(basebackups) > allowed_basebackup_count:
-            self.log.warning("Too many basebackups: %d > %d, %r, starting to get rid of %r",
-                             len(basebackups), allowed_basebackup_count, basebackups, basebackups[0]["name"])
-            basebackup_to_be_deleted = basebackups.pop(0)
+        for basebackup_to_be_deleted in basebackups_to_delete:
             pg_version = basebackup_to_be_deleted["metadata"].get("pg-version")
             last_wal_segment_still_needed = 0
             if basebackups:

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -100,6 +100,75 @@ dbname|"""
         assert basebackups[1]["name"] == "2015-07-02_10"
         assert basebackups[2]["name"] == "2015-07-03_0"
 
+    def test_determine_backups_to_delete(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        bbs = [
+            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=10, hours=4)}},
+            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=9, hours=4)}},
+            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=9, hours=1)}},
+            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=8, hours=4)}},
+            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=7, hours=4)}},
+            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=6, hours=4)}},
+            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=6, hours=20)}},
+            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=5, hours=4)}},
+            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=4, hours=4)}},
+            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=3, hours=4)}},
+            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=2, hours=4)}},
+            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=1, hours=4)}},
+            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(hours=4)}},
+        ]
+
+        site_config = {
+            "basebackup_count": 4,
+            "basebackup_count_min": 2,
+            "basebackup_interval_hours": 24,
+        }
+        bbs_copy = list(bbs)
+        to_delete = self.pghoard.determine_backups_to_delete(basebackups=bbs_copy, site_config=site_config)
+        assert len(bbs_copy) == 4
+        assert len(to_delete) == len(bbs) - len(bbs_copy)
+        assert to_delete == bbs[:len(to_delete)]
+        assert bbs_copy == bbs[len(to_delete):]
+
+        site_config["basebackup_count"] = 16
+        site_config["basebackup_age_days_max"] = 8
+        bbs_copy = list(bbs)
+        to_delete = self.pghoard.determine_backups_to_delete(basebackups=bbs_copy, site_config=site_config)
+        # 3 of the backups are too old (start time + interval is over 8 days in the past)
+        assert len(bbs_copy) == 10
+        assert len(to_delete) == len(bbs) - len(bbs_copy)
+        assert to_delete == bbs[:len(to_delete)]
+        assert bbs_copy == bbs[len(to_delete):]
+
+        site_config["basebackup_count"] = 9
+        bbs_copy = list(bbs)
+        to_delete = self.pghoard.determine_backups_to_delete(basebackups=bbs_copy, site_config=site_config)
+        # basebackup_count trumps backup age and backups are removed even though they're not too old
+        assert len(bbs_copy) == 9
+        assert len(to_delete) == len(bbs) - len(bbs_copy)
+        assert to_delete == bbs[:len(to_delete)]
+        assert bbs_copy == bbs[len(to_delete):]
+
+        site_config["basebackup_count"] = 16
+        site_config["basebackup_age_days_max"] = 2
+        site_config["basebackup_count_min"] = 6
+        bbs_copy = list(bbs)
+        to_delete = self.pghoard.determine_backups_to_delete(basebackups=bbs_copy, site_config=site_config)
+        # basebackup_count_min ensures not that many backups are removed even though they're too old
+        assert len(bbs_copy) == 6
+        assert len(to_delete) == len(bbs) - len(bbs_copy)
+        assert to_delete == bbs[:len(to_delete)]
+        assert bbs_copy == bbs[len(to_delete):]
+
+        site_config["basebackup_count_min"] = 2
+        bbs_copy = list(bbs)
+        to_delete = self.pghoard.determine_backups_to_delete(basebackups=bbs_copy, site_config=site_config)
+        # 3 of the backups are new enough (start time less than 3 days in the past)
+        assert len(bbs_copy) == 3
+        assert len(to_delete) == len(bbs) - len(bbs_copy)
+        assert to_delete == bbs[:len(to_delete)]
+        assert bbs_copy == bbs[len(to_delete):]
+
     def test_local_check_backup_count_and_state(self):
         basebackup_storage_path = os.path.join(self.local_storage_dir, "basebackup")
         wal_storage_path = os.path.join(self.local_storage_dir, "xlog")


### PR DESCRIPTION
Often it is desirable to keep backups for certain period of time. The
backup count setting does allow emulating that to an extent but it does
not work correctly when new basebackups are created manually, in which
case the total count will be exceeded and backups are deleted before
the desired maximum age.