### PR TITLE
Report most recently served files in pghoard state

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -656,6 +656,7 @@ class PGHoard:
             "compression_queue": self.compression_queue.qsize(),
             "transfer_queue": self.transfer_queue.qsize(),
         }
+        self.state["served_files"] = self.webserver.get_most_recently_served_files() if self.webserver else {}
         self.log.debug("Writing JSON state file to %r", state_file_path)
         write_json_file(state_file_path, self.state)
         self.log.debug("Wrote JSON state file to disk, took %.4fs", time.time() - start_time)

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -291,6 +291,7 @@ dbname|"""
                 "compression_queue": 0,
                 "transfer_queue": 0,
             },
+            "served_files": {},
             "transfer_agent_state": {},
             "pg_receivexlogs": {},
             "pg_basebackups": {},

--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -459,6 +459,8 @@ class TestWebServer:
         storage_data = base_data + b"storage"
         on_disk_data = base_data + b"on_disk"
 
+        assert pghoard.webserver.get_most_recently_served_files() == {}
+
         store = pghoard.transfer_agents[0].get_object_storage(pghoard.test_site)
         store.store_file_from_memory(valid_wal, storage_data, metadata={"a": "b"})
 
@@ -487,6 +489,10 @@ class TestWebServer:
         conn.request("GET", valid_wal, headers=headers)
         status = conn.getresponse().status
         assert status == 201
+        recent_files = pghoard.webserver.get_most_recently_served_files()
+        assert list(recent_files) == ["xlog"]
+        assert recent_files["xlog"]["name"] == valid_wal_seg
+        assert 0 < (time.time() - recent_files["xlog"]["time"]) < 1
 
         storage_name = str(tmpdir.join("test_get_storage"))
         headers = {"x-pghoard-target-path": storage_name}


### PR DESCRIPTION
When PostgreSQL is recovering files from archive it may not be accepting
connections so it's not possible to ask the recovery progress from PG
directly. Recovery progress in such cases is in practice the most recent
file of type "xlog" that pghoard has served. Expose this information in
the state file.