### PR TITLE
Keep track of remote xlog and basebackup

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -531,10 +531,10 @@ class PGHoard:
             return  # If a site has been marked inactive, don't bother checking anything
 
         if site not in self.remote_xlog or site not in self.remote_basebackup:
-            self.log.info("Retrieving info from remote storage for %s" % site)
+            self.log.info("Retrieving info from remote storage for %s", site)
             self.remote_xlog[site] = self.get_remote_xlogs_info(site)
             self.remote_basebackup[site] = self.get_remote_basebackups_info(site)
-            self.log.info("Remote info updated for %s" % site)
+            self.log.info("Remote info updated for %s", site)
 
         self._cleanup_inactive_receivexlogs(site)
 

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -118,7 +118,7 @@ class PGHoard:
                 transfer_queue=self.transfer_queue,
                 metrics=self.metrics,
                 shared_state_dict=self.transfer_agent_state,
-                remote_xlog=self.remote_xlog)
+                pghoard=self)
             self.transfer_agents.append(ta)
 
         logutil.notify_systemd("READY=1")

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -415,7 +415,6 @@ class PGHoard:
                 if last_wal_segment_still_needed:
                     self.delete_remote_wal_before(last_wal_segment_still_needed, site, pg_version)
                 self.delete_remote_basebackup(site, basebackup_to_be_deleted)
-        self.state["backup_sites"][site]["basebackups"] = self.remote_basebackup[site]
 
     def get_normalized_backup_time(self, site_config, *, now=None):
         """Returns the closest historical backup time that current time matches to (or current time if it matches).
@@ -536,6 +535,7 @@ class PGHoard:
             self.log.info("Retrieving info from remote storage for %s", site)
             self.remote_xlog[site] = self.get_remote_xlogs_info(site)
             self.remote_basebackup[site] = self.get_remote_basebackups_info(site)
+            self.state["backup_sites"][site]["basebackups"] = self.remote_basebackup[site]
             self.log.info("Remote info updated for %s", site)
 
         self._cleanup_inactive_receivexlogs(site)
@@ -587,7 +587,7 @@ class PGHoard:
         be created at this time"""
         if not now:
             now = datetime.datetime.now(datetime.timezone.utc)
-        basebackups = self.state["backup_sites"][site]["basebackups"]
+        basebackups = self.remote_basebackup[site]
         backup_hour = site_config.get("basebackup_hour")
         backup_minute = site_config.get("basebackup_minute")
         backup_reason = None

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -362,7 +362,7 @@ class PGHoard:
         basebackups_to_delete = []
         for basebackup in self.remote_basebackup[site]:
             if (len(self.remote_basebackup[site]) - len(basebackups_to_delete)) <= allowed_basebackup_count:
-                break;
+                break
             self.log.warning("Too many basebackups: %d > %d, %r, starting to get rid of %r",
                              len(self.remote_basebackup[site]),
                              allowed_basebackup_count,

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -360,13 +360,15 @@ class PGHoard:
             allowed_basebackup_count = len(self.remote_basebackup[site])
 
         basebackups_to_delete = []
-        while len(self.remote_basebackup[site]) > allowed_basebackup_count:
+        for basebackup in self.remote_basebackup[site]:
+            if (len(self.remote_basebackup[site]) - len(basebackups_to_delete)) <= allowed_basebackup_count:
+                break;
             self.log.warning("Too many basebackups: %d > %d, %r, starting to get rid of %r",
                              len(self.remote_basebackup[site]),
                              allowed_basebackup_count,
                              self.remote_basebackup[site],
                              self.remote_basebackup[site][0]["name"])
-            basebackups_to_delete.append(self.remote_basebackup[site][0])
+            basebackups_to_delete.append(basebackup)
 
         backup_interval = datetime.timedelta(hours=site_config["basebackup_interval_hours"])
         min_backups = site_config["basebackup_count_min"]

--- a/pghoard/transfer.py
+++ b/pghoard/transfer.py
@@ -24,7 +24,7 @@ _last_stats_transmit_time = 0
 
 class TransferAgent(Thread):
     def __init__(self, config, compression_queue, mp_manager, transfer_queue, metrics,
-                 shared_state_dict):
+                 shared_state_dict, pghoard):
         super().__init__()
         self.log = logging.getLogger("TransferAgent")
         self.config = config
@@ -36,6 +36,7 @@ class TransferAgent(Thread):
         self.running = True
         self.sleep = time.sleep
         self.state = shared_state_dict
+        self.pghoard = pghoard
         self.site_transfers = {}
         self.log.debug("TransferAgent initialized")
 
@@ -252,6 +253,17 @@ class TransferAgent(Thread):
                 except Exception as ex:  # pylint: disable=broad-except
                     self.log.exception("Problem in deleting file: %r", file_to_transfer["local_path"])
                     self.metrics.unexpected_exception(ex, where="handle_upload_unlink")
+
+            # update metrics for remote xlog and base backup
+            if file_to_transfer.get('filetype') == 'xlog':
+                self.pghoard.remote_xlog[site].append(os.path.basename(key))
+            elif file_to_transfer.get('filetype') == 'basebackup':
+                new_basebackup = list(storage.iter_key(key, include_key=True))[0].value
+                # patch metadata
+                self.pghoard.patch_basebackup_info(entry=new_basebackup,
+                                                   site_config=self.pghoard.config["backup_sites"][site])
+                self.pghoard.remote_basebackup[site].append(new_basebackup)
+
             return {"success": True, "opaque": file_to_transfer.get("opaque")}
         except Exception as ex:  # pylint: disable=broad-except
             if file_to_transfer.get("retry_number", 0) > 0:

--- a/test/base.py
+++ b/test/base.py
@@ -6,7 +6,7 @@ See LICENSE for details
 """
 # pylint: disable=attribute-defined-outside-init
 from pghoard.config import find_pg_binary, set_and_check_config_defaults
-from pghoard.rohmu import compat
+from pghoard.rohmu import compat, dates
 from shutil import rmtree
 from tempfile import mkdtemp
 import logging
@@ -101,5 +101,12 @@ class PGHoardTestCase:
         self.remote_xlog[self.test_site] = []
         self.remote_basebackup[self.test_site] = []
 
-    def teardown_method(self, method):  # pylint: disable=unused-argument
+    def teardown_method(self, method):
         rmtree(self.temp_dir)
+
+    def patch_basebackup_info(self, *, entry, site_config):  # pylint: disable=unused-argument
+        # drop path from resulting list and convert timestamps
+        entry["name"] = os.path.basename(entry["name"])
+        metadata = entry["metadata"]
+        metadata["start-time"] = dates.parse_timestamp(metadata["start-time"])
+

--- a/test/base.py
+++ b/test/base.py
@@ -101,7 +101,7 @@ class PGHoardTestCase:
         self.remote_xlog[self.test_site] = []
         self.remote_basebackup[self.test_site] = []
 
-    def teardown_method(self, method):
+    def teardown_method(self, method):  # pylint: disable=unused-argument
         rmtree(self.temp_dir)
 
     def patch_basebackup_info(self, *, entry, site_config):  # pylint: disable=unused-argument

--- a/test/base.py
+++ b/test/base.py
@@ -96,6 +96,10 @@ class PGHoardTestCase:
     def setup_method(self, method):
         self.temp_dir = mkdtemp(prefix=self.__class__.__name__)
         self.test_site = "site_{}".format(method.__name__)
+        self.remote_xlog = {}
+        self.remote_basebackup = {}
+        self.remote_xlog[self.test_site] = []
+        self.remote_basebackup[self.test_site] = []
 
     def teardown_method(self, method):  # pylint: disable=unused-argument
         rmtree(self.temp_dir)

--- a/test/base.py
+++ b/test/base.py
@@ -109,4 +109,3 @@ class PGHoardTestCase:
         entry["name"] = os.path.basename(entry["name"])
         metadata = entry["metadata"]
         metadata["start-time"] = dates.parse_timestamp(metadata["start-time"])
-

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -274,6 +274,10 @@ def pghoard_base(db, tmpdir, request, compression="snappy",   # pylint: disable=
 
     pgh = PGHoard(confpath)
     pgh.test_site = test_site
+    pgh.remote_xlog = {}
+    pgh.remote_basebackup = {}
+    pgh.remote_xlog[pgh.test_site] = []
+    pgh.remote_basebackup[pgh.test_site] = []
     pgh.start_threads_on_startup()
     if compression == "snappy":
         pgh.Compressor = snappy.StreamCompressor

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -278,6 +278,8 @@ def pghoard_base(db, tmpdir, request, compression="snappy",   # pylint: disable=
     pgh.remote_basebackup = {}
     pgh.remote_xlog[pgh.test_site] = []
     pgh.remote_basebackup[pgh.test_site] = []
+    pgh.set_state_defaults(pgh.test_site)
+    pgh.state["backup_sites"][pgh.test_site]["basebackups"] = pgh.remote_basebackup[pgh.test_site]
     pgh.start_threads_on_startup()
     if compression == "snappy":
         pgh.Compressor = snappy.StreamCompressor

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -193,6 +193,8 @@ LABEL: pg_basebackup base backup
 
         pghoard.config["backup_sites"][pghoard.test_site]["basebackup_mode"] = mode
         pghoard.config["backup_sites"][pghoard.test_site]["active_backup_mode"] = active_backup_mode
+        pghoard.remote_xlog[pghoard.test_site] = []
+        pghoard.remote_basebackup[pghoard.test_site] = []
 
         now = datetime.datetime.now(datetime.timezone.utc)
         metadata = {

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -609,6 +609,9 @@ LABEL: pg_basebackup base backup
 
         site = pghoard.test_site
         pghoard.set_state_defaults(site)
+        pghoard.remote_xlog[site] = pghoard.get_remote_xlogs_info(site)
+        pghoard.remote_basebackup[site] = pghoard.get_remote_basebackups_info(site)
+        pghoard.state["backup_sites"][site]["basebackups"] = pghoard.remote_basebackup[site]
         site_config = pghoard.config["backup_sites"][site]
 
         # No backups, one should be created. No backup schedule defined so normalized backup time is None

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -193,8 +193,6 @@ LABEL: pg_basebackup base backup
 
         pghoard.config["backup_sites"][pghoard.test_site]["basebackup_mode"] = mode
         pghoard.config["backup_sites"][pghoard.test_site]["active_backup_mode"] = active_backup_mode
-        pghoard.remote_xlog[pghoard.test_site] = []
-        pghoard.remote_basebackup[pghoard.test_site] = []
 
         now = datetime.datetime.now(datetime.timezone.utc)
         metadata = {
@@ -536,7 +534,6 @@ LABEL: pg_basebackup base backup
         site_config = deepcopy(pghoard.config["backup_sites"][pghoard.test_site])
         site_config["basebackup_interval_hours"] = 1 / 3600
         assert pghoard.basebackups == {}
-        assert pghoard.test_site not in pghoard.remote_basebackup
 
         # initialize with a single backup
         backup_start = time.monotonic()

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -606,9 +606,6 @@ LABEL: pg_basebackup base backup
 
         site = pghoard.test_site
         pghoard.set_state_defaults(site)
-        pghoard.remote_xlog[site] = pghoard.get_remote_xlogs_info(site)
-        pghoard.remote_basebackup[site] = pghoard.get_remote_basebackups_info(site)
-        pghoard.state["backup_sites"][site]["basebackups"] = pghoard.remote_basebackup[site]
         site_config = pghoard.config["backup_sites"][site]
 
         # No backups, one should be created. No backup schedule defined so normalized backup time is None

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -536,6 +536,7 @@ LABEL: pg_basebackup base backup
         site_config = deepcopy(pghoard.config["backup_sites"][pghoard.test_site])
         site_config["basebackup_interval_hours"] = 1 / 3600
         assert pghoard.basebackups == {}
+        assert pghoard.test_site not in pghoard.remote_basebackup
 
         # initialize with a single backup
         backup_start = time.monotonic()
@@ -559,7 +560,7 @@ LABEL: pg_basebackup base backup
         # now call handle_site so it notices the backup has finished (this must not start a new one)
         pghoard.handle_site(pghoard.test_site, site_config)
         assert pghoard.test_site not in pghoard.basebackups
-        first_basebackups = pghoard.state["backup_sites"][pghoard.test_site]["basebackups"]
+        first_basebackups = pghoard.remote_basebackup[pghoard.test_site][:]
         assert first_basebackups[0]["metadata"]["backup-reason"] == "scheduled"
         assert first_basebackups[0]["metadata"]["backup-decision-time"]
         assert first_basebackups[0]["metadata"]["normalized-backup-time"] is None
@@ -572,7 +573,7 @@ LABEL: pg_basebackup base backup
         pghoard.handle_site(pghoard.test_site, site_config)
         assert pghoard.test_site not in pghoard.basebackups
 
-        second_basebackups = pghoard.state["backup_sites"][pghoard.test_site]["basebackups"]
+        second_basebackups = pghoard.remote_basebackup[pghoard.test_site][:]
         second_time_of_check = pghoard.time_of_last_backup_check[pghoard.test_site]
         assert second_basebackups == first_basebackups
         assert second_time_of_check > first_time_of_check
@@ -586,7 +587,7 @@ LABEL: pg_basebackup base backup
         pghoard.handle_site(pghoard.test_site, site_config)
         assert pghoard.test_site not in pghoard.basebackups
 
-        third_basebackups = pghoard.state["backup_sites"][pghoard.test_site]["basebackups"]
+        third_basebackups = pghoard.remote_basebackup[pghoard.test_site][:]
         third_time_of_check = pghoard.time_of_last_backup_check[pghoard.test_site]
         assert third_basebackups != second_basebackups
         assert third_time_of_check > second_time_of_check
@@ -596,7 +597,7 @@ LABEL: pg_basebackup base backup
         pghoard.handle_site(pghoard.test_site, site_config)
         assert pghoard.test_site not in pghoard.basebackups
 
-        fourth_basebackups = pghoard.state["backup_sites"][pghoard.test_site]["basebackups"]
+        fourth_basebackups = pghoard.remote_basebackup[pghoard.test_site][:]
         fourth_time_of_check = pghoard.time_of_last_backup_check[pghoard.test_site]
         assert fourth_basebackups == third_basebackups
         assert fourth_time_of_check == third_time_of_check

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -109,50 +109,46 @@ dbname|"""
         now = datetime.datetime.now(datetime.timezone.utc)
         bbs = [
             {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=10, hours=4)}},
-            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=9, hours=4)}},
-            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=9, hours=1)}},
-            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=8, hours=4)}},
-            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=7, hours=4)}},
-            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=6, hours=4)}},
-            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=6, hours=20)}},
-            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=5, hours=4)}},
-            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=4, hours=4)}},
-            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=3, hours=4)}},
-            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=2, hours=4)}},
-            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(days=1, hours=4)}},
-            {"name": "bb1", "metadata": {"start-time": now - datetime.timedelta(hours=4)}},
+            {"name": "bb2", "metadata": {"start-time": now - datetime.timedelta(days=9, hours=4)}},
+            {"name": "bb3", "metadata": {"start-time": now - datetime.timedelta(days=9, hours=1)}},
+            {"name": "bb4", "metadata": {"start-time": now - datetime.timedelta(days=8, hours=4)}},
+            {"name": "bb5", "metadata": {"start-time": now - datetime.timedelta(days=7, hours=4)}},
+            {"name": "bb6", "metadata": {"start-time": now - datetime.timedelta(days=6, hours=4)}},
+            {"name": "bb7", "metadata": {"start-time": now - datetime.timedelta(days=6, hours=20)}},
+            {"name": "bb8", "metadata": {"start-time": now - datetime.timedelta(days=5, hours=4)}},
+            {"name": "bb9", "metadata": {"start-time": now - datetime.timedelta(days=4, hours=4)}},
+            {"name": "bb10", "metadata": {"start-time": now - datetime.timedelta(days=3, hours=4)}},
+            {"name": "bb11", "metadata": {"start-time": now - datetime.timedelta(days=2, hours=4)}},
+            {"name": "bb12", "metadata": {"start-time": now - datetime.timedelta(days=1, hours=4)}},
+            {"name": "bb13", "metadata": {"start-time": now - datetime.timedelta(hours=4)}},
         ]
 
+        basebackup_count = 4
         site_config = {
-            "basebackup_count": 4,
+            "basebackup_count": basebackup_count,
             "basebackup_count_min": 2,
             "basebackup_interval_hours": 24,
         }
-        bbs_copy = list(bbs)
+        self.pghoard.config["backup_sites"][self.test_site] = site_config
+        self.pghoard.remote_basebackup[self.test_site] = bbs
         to_delete = self.pghoard.determine_backups_to_delete(self.test_site)
-        assert len(bbs_copy) == 4
-        assert len(to_delete) == len(bbs) - len(bbs_copy)
+        a = len(to_delete)
+        assert len(bbs) - len(to_delete) == 4
         assert to_delete == bbs[:len(to_delete)]
-        assert bbs_copy == bbs[len(to_delete):]
 
         site_config["basebackup_count"] = 16
         site_config["basebackup_age_days_max"] = 8
-        bbs_copy = list(bbs)
         to_delete = self.pghoard.determine_backups_to_delete(self.test_site)
         # 3 of the backups are too old (start time + interval is over 8 days in the past)
-        assert len(bbs_copy) == 10
-        assert len(to_delete) == len(bbs) - len(bbs_copy)
+        assert len(to_delete) == 3
         assert to_delete == bbs[:len(to_delete)]
-        assert bbs_copy == bbs[len(to_delete):]
 
         site_config["basebackup_count"] = 9
-        bbs_copy = list(bbs)
         to_delete = self.pghoard.determine_backups_to_delete(self.test_site)
         # basebackup_count trumps backup age and backups are removed even though they're not too old
-        assert len(bbs_copy) == 9
-        assert len(to_delete) == len(bbs) - len(bbs_copy)
+        a = len(to_delete)
+        assert len(to_delete) == 9
         assert to_delete == bbs[:len(to_delete)]
-        assert bbs_copy == bbs[len(to_delete):]
 
         site_config["basebackup_count"] = 16
         site_config["basebackup_age_days_max"] = 2

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -132,7 +132,6 @@ dbname|"""
         self.pghoard.config["backup_sites"][self.test_site] = site_config
         self.pghoard.remote_basebackup[self.test_site] = bbs
         to_delete = self.pghoard.determine_backups_to_delete(self.test_site)
-        a = len(to_delete)
         assert len(bbs) - len(to_delete) == 4
         assert to_delete == bbs[:len(to_delete)]
 
@@ -146,7 +145,6 @@ dbname|"""
         site_config["basebackup_count"] = 9
         to_delete = self.pghoard.determine_backups_to_delete(self.test_site)
         # basebackup_count trumps backup age and backups are removed even though they're not too old
-        a = len(to_delete)
         assert len(to_delete) == 9
         assert to_delete == bbs[:len(to_delete)]
 

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -147,7 +147,7 @@ dbname|"""
         site_config["basebackup_age_days_max"] = 10
         to_delete = self.pghoard.determine_backups_to_delete(self.test_site)
         # basebackup_count trumps backup age and backups are removed even though they're not too old
-        # We have 13 basebackups, 12 with start-time < 8 days
+        # We have 13 basebackups, 12 with start-time < 10 days
         # So based with basebackup_count = 9 pghoard should delete 4 backups (bb1, bb2, bb3, bb4)
         # And with basebackup_age_days_max = 10 days pghoard should delete 1 backup (bb1)
         assert len(to_delete) == 4

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -129,7 +129,7 @@ dbname|"""
             "basebackup_interval_hours": 24,
         }
         bbs_copy = list(bbs)
-        to_delete = self.pghoard.determine_backups_to_delete(basebackups=bbs_copy, site_config=site_config)
+        to_delete = self.pghoard.determine_backups_to_delete(self.test_site)
         assert len(bbs_copy) == 4
         assert len(to_delete) == len(bbs) - len(bbs_copy)
         assert to_delete == bbs[:len(to_delete)]
@@ -138,7 +138,7 @@ dbname|"""
         site_config["basebackup_count"] = 16
         site_config["basebackup_age_days_max"] = 8
         bbs_copy = list(bbs)
-        to_delete = self.pghoard.determine_backups_to_delete(basebackups=bbs_copy, site_config=site_config)
+        to_delete = self.pghoard.determine_backups_to_delete(self.test_site)
         # 3 of the backups are too old (start time + interval is over 8 days in the past)
         assert len(bbs_copy) == 10
         assert len(to_delete) == len(bbs) - len(bbs_copy)
@@ -147,7 +147,7 @@ dbname|"""
 
         site_config["basebackup_count"] = 9
         bbs_copy = list(bbs)
-        to_delete = self.pghoard.determine_backups_to_delete(basebackups=bbs_copy, site_config=site_config)
+        to_delete = self.pghoard.determine_backups_to_delete(self.test_site)
         # basebackup_count trumps backup age and backups are removed even though they're not too old
         assert len(bbs_copy) == 9
         assert len(to_delete) == len(bbs) - len(bbs_copy)
@@ -158,7 +158,7 @@ dbname|"""
         site_config["basebackup_age_days_max"] = 2
         site_config["basebackup_count_min"] = 6
         bbs_copy = list(bbs)
-        to_delete = self.pghoard.determine_backups_to_delete(basebackups=bbs_copy, site_config=site_config)
+        to_delete = self.pghoard.determine_backups_to_delete(self.test_site)
         # basebackup_count_min ensures not that many backups are removed even though they're too old
         assert len(bbs_copy) == 6
         assert len(to_delete) == len(bbs) - len(bbs_copy)
@@ -167,7 +167,7 @@ dbname|"""
 
         site_config["basebackup_count_min"] = 2
         bbs_copy = list(bbs)
-        to_delete = self.pghoard.determine_backups_to_delete(basebackups=bbs_copy, site_config=site_config)
+        to_delete = self.pghoard.determine_backups_to_delete(self.test_site)
         # 3 of the backups are new enough (start time less than 3 days in the past)
         assert len(bbs_copy) == 3
         assert len(to_delete) == len(bbs) - len(bbs_copy)

--- a/test/test_transferagent.py
+++ b/test/test_transferagent.py
@@ -26,14 +26,13 @@ import time
 class MockStorage(Mock):
 
     def init(self):
-        if self.init_ok is not True:
+        if self.init_ok is not True:  # pylint: disable=access-member-before-definition
             self.objects = {}
             now = datetime.datetime.now(dateutil.tz.tzlocal())
             self.sample_storage_date = "{} {}".format(now.isoformat().split("+", 1)[0], now.tzname())
             self.init_ok = True
 
-    def setup_method(self, method):
-        super().setup_method(method)
+    def setup_method(self):
         self.init()
 
     def get_contents_to_string(self, key):  # pylint: disable=unused-argument
@@ -44,9 +43,9 @@ class MockStorage(Mock):
         self.init()
         self.objects[key] = local_path
 
-    def iter_key(self, key, *, with_metadata=True, deep=False, include_key=False):
+    def iter_key(self, key, *, with_metadata=True, deep=False, include_key=False):  # pylint: disable=unused-argument
         self.init()
-        for item in self.objects.keys():
+        for item in self.objects:
             if key == item[0:len(key)]:
                 yield IterKeyItem(
                     type=KEY_TYPE_OBJECT,

--- a/test/test_transferagent.py
+++ b/test/test_transferagent.py
@@ -26,12 +26,11 @@ import time
 class MockStorage(Mock):
 
     def init(self):
-        if self.init_ok != True:
+        if self.init_ok is not True:
             self.objects = {}
             now = datetime.datetime.now(dateutil.tz.tzlocal())
             self.sample_storage_date = "{} {}".format(now.isoformat().split("+", 1)[0], now.tzname())
             self.init_ok = True
-
 
     def setup_method(self, method):
         super().setup_method(method)

--- a/test/test_transferagent.py
+++ b/test/test_transferagent.py
@@ -5,6 +5,13 @@ Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details
 """
 # pylint: disable=attribute-defined-outside-init
+import datetime
+import hashlib
+
+import dateutil
+
+from pghoard.rohmu.object_storage.base import IterKeyItem, KEY_TYPE_OBJECT
+
 from .base import PGHoardTestCase
 from pghoard import metrics
 from pghoard.rohmu.errors import FileNotFoundFromStorageError, StorageError
@@ -17,11 +24,41 @@ import time
 
 
 class MockStorage(Mock):
+
+    def init(self):
+        if self.init_ok != True:
+            self.objects = {}
+            now = datetime.datetime.now(dateutil.tz.tzlocal())
+            self.sample_storage_date = "{} {}".format(now.isoformat().split("+", 1)[0], now.tzname())
+            self.init_ok = True
+
+
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.init()
+
     def get_contents_to_string(self, key):  # pylint: disable=unused-argument
+        self.init()
         return b"joo", {"key": "value"}
 
     def store_file_from_disk(self, key, local_path, metadata, multipart=None):  # pylint: disable=unused-argument
-        pass
+        self.init()
+        self.objects[key] = local_path
+
+    def iter_key(self, key, *, with_metadata=True, deep=False, include_key=False):
+        self.init()
+        for item in self.objects.keys():
+            if key == item[0:len(key)]:
+                yield IterKeyItem(
+                    type=KEY_TYPE_OBJECT,
+                    value={
+                        "last_modified": self.sample_storage_date,
+                        "md5": hashlib.md5(item.encode()).hexdigest(),
+                        "metadata": {"start-time": self.sample_storage_date},
+                        "name": item,
+                        "size": len(self.objects[item]),
+                    },
+                )
 
 
 class MockStorageRaising(Mock):
@@ -30,12 +67,6 @@ class MockStorageRaising(Mock):
 
     def store_file_from_disk(self, key, local_path, metadata, multipart=None):  # pylint: disable=unused-argument
         raise StorageError("foo")
-
-
-class MockPGHoard(Mock):
-    def __init__(self):
-        self.remote_xlog = {}
-        self.remote_basebackup = {}
 
 
 class TestTransferAgent(PGHoardTestCase):
@@ -71,7 +102,7 @@ class TestTransferAgent(PGHoardTestCase):
             transfer_queue=self.transfer_queue,
             metrics=metrics.Metrics(statsd={}),
             shared_state_dict={},
-            pghoard=MockPGHoard())
+            pghoard=self)
         self.transfer_agent.start()
 
     def teardown_method(self, method):

--- a/test/test_transferagent.py
+++ b/test/test_transferagent.py
@@ -32,6 +32,12 @@ class MockStorageRaising(Mock):
         raise StorageError("foo")
 
 
+class MockPGHoard(Mock):
+    def __init__(self):
+        self.remote_xlog = {}
+        self.remote_basebackup = {}
+
+
 class TestTransferAgent(PGHoardTestCase):
     def setup_method(self, method):
         super().setup_method(method)
@@ -64,7 +70,8 @@ class TestTransferAgent(PGHoardTestCase):
             mp_manager=None,
             transfer_queue=self.transfer_queue,
             metrics=metrics.Metrics(statsd={}),
-            shared_state_dict={})
+            shared_state_dict={},
+            pghoard=MockPGHoard())
         self.transfer_agent.start()
 
     def teardown_method(self, method):


### PR DESCRIPTION
The purpose of this PR is to keep tracks of remote files uploaded. As mentioned in #366, with a list of xlog on remote storage, we can compute several new metrics and check if there is gap in the xlog sequence. This PR is a based for another PR that will add new metrics as described in #366.

This PR mainly adds 2 attributes on PGHoard class:
* `remote_xlog`
* `remote_basebackup`

and code to keep those attributes up to date:

* First run of `handle_site()` will fetch xlogs and basebackups from remote storage and populates `remote_xlog` and `remote_basebackup` attributes.
* On successful tranfert, new xlog or basebackup will be added to `remote_xlog` and `remote_basebackup` attributes.
* When deleting xlog or basebackup, `remote_xlog` or `remote_basebackup` attributes will be updated.

Additionally, this PR merge `remote_basebackup` attribute with `state["backup_sites"][site]["basebackups"]`:

```python
self.state["backup_sites"][site]["basebackups"] = self.remote_basebackup[site]
```