### PR TITLE
basebackup: Use multiple threads to compress and encrypt chunks

### DIFF
--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -14,6 +14,7 @@ from .common import (
     terminate_subprocess,
 )
 from .patchedtarfile import tarfile
+from concurrent.futures import ThreadPoolExecutor
 from pghoard.rohmu import dates, errors, rohmufile
 from pghoard.rohmu.compat import suppress
 from queue import Empty, Queue
@@ -65,6 +66,7 @@ class PGBaseBackup(Thread):
         self.connection_info = connection_info
         self.basebackup_path = basebackup_path
         self.callback_queue = callback_queue
+        self.chunks_on_disk = 0
         self.compression_queue = compression_queue
         self.metadata = metadata or {}
         self.metrics = metrics
@@ -526,39 +528,64 @@ class PGBaseBackup(Thread):
                              time.monotonic() - start_time)
         return False
 
+    def handle_single_chunk(self, *, chunk_callback_queue, chunk_path, chunks, index, temp_dir):
+        one_chunk_files = chunks[index]
+        chunk_name, input_size, result_size = self.tar_one_file(
+            callback_queue=chunk_callback_queue,
+            chunk_path=chunk_path,
+            temp_dir=temp_dir,
+            files_to_backup=one_chunk_files,
+        )
+        self.log.info(
+            "Queued backup chunk %r for transfer, chunks on disk (including partial): %r, current: %r, total chunks: %r",
+            chunk_name, self.chunks_on_disk + 1, index, len(chunks)
+        )
+        return {
+            "chunk_filename": chunk_name,
+            "input_size": input_size,
+            "result_size": result_size,
+            "files": [chunk[0] for chunk in one_chunk_files]
+        }
+
     def create_and_upload_chunks(self, chunks, data_file_format, temp_base_dir):
         start_time = time.monotonic()
         chunk_files = []
         upload_results = []
         chunk_callback_queue = Queue()
-        chunks_on_disk = 0
+        self.chunks_on_disk = 0
         i = 0
 
-        while i < len(chunks):
-            if chunks_on_disk < self.config["backup_sites"][self.site]["basebackup_chunks_in_progress"]:
-                chunk_id = i + 1
-                one_chunk_files = chunks[i]
+        max_chunks_on_disk = self.config["backup_sites"][self.site]["basebackup_chunks_in_progress"]
+        with ThreadPoolExecutor(max_workers=max_chunks_on_disk) as tpe:
+            pending_compress_and_encrypt_tasks = []
+            while i < len(chunks):
+                if len(pending_compress_and_encrypt_tasks) >= max_chunks_on_disk:
+                    # Always expect tasks to complete in order. This can slow down the progress a bit in case
+                    # one chunk is much slower to process than others but typically the chunks don't differ much
+                    # and this assumption greatly simplifies the logic.
+                    task_to_wait = pending_compress_and_encrypt_tasks.pop(0)
+                    chunk_files.append(task_to_wait.result())
 
-                chunk_name, input_size, result_size = self.tar_one_file(
-                    callback_queue=chunk_callback_queue,
-                    chunk_path=data_file_format(chunk_id),
-                    temp_dir=temp_base_dir,
-                    files_to_backup=one_chunk_files,
-                )
-                chunk_files.append(
-                    {
-                        "chunk_filename": chunk_name,
-                        "input_size": input_size,
-                        "result_size": result_size,
-                        "files": [chunk[0] for chunk in one_chunk_files]
-                    }
-                )
-                chunks_on_disk += 1
-                i += 1
-                self.log.info("Queued backup chunk %r for transfer, chunks_on_disk: %r, current: %r, total_chunks: %r",
-                              chunk_name, chunks_on_disk, i, len(chunks))
-            elif self.wait_for_chunk_transfer_to_complete(len(chunks), upload_results, chunk_callback_queue, start_time):
-                chunks_on_disk -= 1
+                if self.chunks_on_disk < max_chunks_on_disk:
+                    chunk_id = i + 1
+                    task = tpe.submit(
+                        self.handle_single_chunk,
+                        chunk_callback_queue=chunk_callback_queue,
+                        chunk_path=data_file_format(chunk_id),
+                        chunks=chunks,
+                        index=i,
+                        temp_dir=temp_base_dir,
+                    )
+                    pending_compress_and_encrypt_tasks.append(task)
+                    self.chunks_on_disk += 1
+                    i += 1
+                else:
+                    if self.wait_for_chunk_transfer_to_complete(
+                            len(chunks), upload_results, chunk_callback_queue, start_time
+                    ):
+                        self.chunks_on_disk -= 1
+            for task in pending_compress_and_encrypt_tasks:
+                chunk_files.append(task.result())
 
         while len(upload_results) < len(chunk_files):
             self.wait_for_chunk_transfer_to_complete(len(chunks), upload_results, chunk_callback_queue, start_time)

--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -36,7 +36,8 @@ class RestoreError(Error):
 
 def create_signal_file(file_path):
     """Just ensure the file exists"""
-    open(file_path, "w")
+    with open(file_path, "w"):
+        pass
 
 
 def create_recovery_conf(dirpath, site, *,


### PR DESCRIPTION
Taking basebackups of very large systems took a long time because each
basebackup chunk was compressed and encrypted completely sequentially.
(Uploading was done in parallel.) While GIL does not allow fully
utilizing a lot of CPU cores the native calls do release it so this
somewhat reduces basebackup duration on multi core nodes.

On a 4 CPU core machine before the changes:

```
Nov 21 19:33:34 hostname pghoard[4113]: PGBaseBackup Thread-17 INFO: Starting to backup ...
Nov 21 19:37:16 hostname pghoard[4113]: PGBaseBackup Thread-17 INFO: Basebackup generation finished, 1431 files, 11 chunks, 20964014080 byte input, 5968819920 byte output, took 221.98487178200048 seconds, waiting to upload
```

and after the changes:

```
Nov 21 22:38:56 hostname pghoard[30484]: PGBaseBackup Thread-16 INFO: Starting to backup ...
Nov 21 22:41:20 hostname pghoard[30484]: PGBaseBackup Thread-16 INFO: Basebackup generation finished, 1431 files, 11 chunks, 20964024320 byte input, 5968819975 byte output, took 144.12692216699907 seconds, waiting to upload
```