### PR TITLE
basebackup: Use multiple threads to compress and encrypt chunks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -624,6 +624,12 @@ In how large backup chunks to take a ``local-tar`` basebackup. Disk
 space needed for a successful backup is this variable multiplied by
 ``basebackup_chunks_in_progress``.
 
+``basebackup_compression_threads`` (default ``0``)
+
+Number of threads to use within compression library during basebackup. Only
+applicable when using compression library that supports internal multithreading,
+namely zstd at the moment. Default value 0 means not to use multithreading.
+
 ``basebackup_count`` (default ``2``)
 
 How many basebackups should be kept around for restoration purposes.  The
@@ -683,6 +689,13 @@ tablespaces.
 
 Note that the ``local-tar`` backup mode can not be used on replica servers
 prior to PostgreSQL 9.6 unless the pgespresso extension is installed.
+
+``basebackup_threads`` (default ``1``)
+
+How many threads to use for tar, compress and encrypt tasks. Only applies for
+``local-tar`` basebackup mode. Only values 1 and 2 are likely to be sensible for
+this, with higher thread count speed improvement is negligible and CPU time is
+lost switching between threads.
 
 ``encryption_key_id`` (no default)
 

--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -82,12 +82,14 @@ def set_and_check_config_defaults(config, *, check_commands=True, check_pgdata=T
 
         site_config.setdefault("basebackup_chunk_size", 1024 * 1024 * 1024 * 2)
         site_config.setdefault("basebackup_chunks_in_progress", 5)
+        site_config.setdefault("basebackup_compression_threads", 0)
         site_config.setdefault("basebackup_count", 2)
         site_config.setdefault("basebackup_count_min", 2)
         site_config.setdefault("basebackup_interval_hours", 24)
         # NOTE: stream_compression removed from documentation after 1.6.0 release
         site_config.setdefault("basebackup_mode",
                                "pipe" if site_config.get("stream_compression") else "basic")
+        site_config.setdefault("basebackup_threads", 1)
         site_config.setdefault("encryption_key_id", None)
         site_config.setdefault("object_storage", None)
         pg_receivexlog_config = site_config.setdefault("pg_receivexlog", {})

--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -36,7 +36,8 @@ class RestoreError(Error):
 
 def create_signal_file(file_path):
     """Just ensure the file exists"""
-    open(file_path, "w")
+    with open(file_path, "w"):
+        pass
 
 
 def create_recovery_conf(dirpath, site, *,

--- a/pghoard/rohmu/compressor.py
+++ b/pghoard/rohmu/compressor.py
@@ -22,7 +22,7 @@ except ImportError:
     zstd = None
 
 
-def CompressionFile(dst_fp, algorithm, level=0):
+def CompressionFile(dst_fp, algorithm, level=0, threads=0):
     """This looks like a class to users, but is actually a function that instantiates a class based on algorithm."""
     if algorithm == "lzma":
         return lzma.open(dst_fp, "w", preset=level)
@@ -31,7 +31,7 @@ def CompressionFile(dst_fp, algorithm, level=0):
         return SnappyFile(dst_fp, "wb")
 
     if algorithm == "zstd":
-        return zstd_open(dst_fp, "wb")
+        return zstd_open(dst_fp, "wb", threads=threads)
 
     if algorithm:
         raise InvalidConfigurationError("invalid compression algorithm: {!r}".format(algorithm))

--- a/pghoard/rohmu/rohmufile.py
+++ b/pghoard/rohmu/rohmufile.py
@@ -95,12 +95,12 @@ def read_file(*, input_obj, output_obj, metadata, key_lookup, progress_callback=
     return original_size, result_size
 
 
-def file_writer(*, fileobj, compression_algorithm=None, compression_level=0, rsa_public_key=None):
+def file_writer(*, fileobj, compression_algorithm=None, compression_level=0, compression_threads=0, rsa_public_key=None):
     if rsa_public_key:
         fileobj = EncryptorFile(fileobj, rsa_public_key)
 
     if compression_algorithm:
-        fileobj = CompressionFile(fileobj, compression_algorithm, compression_level)
+        fileobj = CompressionFile(fileobj, compression_algorithm, compression_level, compression_threads)
 
     return fileobj
 

--- a/pghoard/rohmu/zstdfile.py
+++ b/pghoard/rohmu/zstdfile.py
@@ -17,8 +17,8 @@ except ImportError:
 
 class _ZstdFileWriter(FileWrap):
 
-    def __init__(self, next_fp, level):
-        self._zstd = zstd.ZstdCompressor(level=level).compressobj()
+    def __init__(self, next_fp, level, threads=0):
+        self._zstd = zstd.ZstdCompressor(level=level, threads=threads).compressobj()
         super().__init__(next_fp)
 
     def close(self):
@@ -74,12 +74,12 @@ class _ZtsdFileReader(FileWrap):
         return True
 
 
-def open(fp, mode, level=0):  # pylint: disable=redefined-builtin
+def open(fp, mode, level=0, threads=0):  # pylint: disable=redefined-builtin
     if zstd is None:
         raise io.UnsupportedOperation("zstd is not available")
 
     if mode == "wb":
-        return _ZstdFileWriter(fp, level)
+        return _ZstdFileWriter(fp, level, threads)
 
     if mode == "rb":
         return _ZtsdFileReader(fp)


### PR DESCRIPTION
Taking basebackups of very large systems takes a long time. Previously
each basebackup chunk was compressed and encrypted completely
sequentially. (Uploading was done in parallel.) While GIL does not
allow fully utilizing a lot of CPU cores the native calls do release it
so this somewhat reduces basebackup duration on multi core nodes.

Test results with 44 GiB database, 23 basebackup chunks, zstd
compression:

```
Baseline:
  CPU consumption: 100% - 120%
  Operation duration: 510s
  CPU time: 530s
One thread (but using ThreadPoolExecutor):
  CPU consumption: 100% - 120%
  Operation duration: 505s
  CPU time: 533s
Two threads:
  CPU consumption: 190% - 230%
  Operation duration: 290s
  CPU time: 586s
Five threads:
  CPU consumption: 240% - 480%
  Operation duration: 292s
  CPU time: 970s
Two threads plus two zstd threads:
  CPU consumption: 250% - 510%
  Operation duration: 196s
  CPU time: 622s
Two threads plus four zstd threads:
  CPU consumption: 250% - 520%
  Operation duration: 202s
  CPU time: 808s
Two threads with snappy:
  CPU consumption: 170% - 230%
  Operation duration: 378s
  CPU time: 767s
```

Going from one to two threads does add some overhead but not a whole lot
and the execution time is reduced quite a bit. Making zstd use two
threads further reduces the execution time significantly with some more
overhead (variance was rather high, some tests performed better than 622
CPU seconds, others worse). Other options do not perform especially
well.