### PR TITLE
rohmu: Fix re-reading data from GCS

### DIFF
--- a/pghoard/rohmu/object_storage/google.py
+++ b/pghoard/rohmu/object_storage/google.py
@@ -416,7 +416,7 @@ class MediaStreamUpload(MediaUpload):
         return True
 
     def getbytes(self, begin, end):
-        length = end
+        length = end - begin
         if begin < (self._position or 0):
             msg = "Requested position {} for {!r} preceeds already fulfilled position {}".format(
                 begin, self._name, self._position
@@ -430,8 +430,8 @@ class MediaStreamUpload(MediaUpload):
 
         if self._position is None or begin == self._position + len(self._data):
             self._data = self._read_bytes(length)
-        elif begin != self._position:
-            retain_chunk = self._data[begin - self._position]
+        elif begin != self._position or length > len(self._data):
+            retain_chunk = self._data[begin - self._position:]
             self._data = self._read_bytes(length - len(retain_chunk), initial_data=retain_chunk)
 
         self._position = begin

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,10 @@ astroid
 botocore
 cryptography
 flake8
+google-api-python-client
 httplib2 
 mock
+oauth2client
 psycopg2
 pylint>=2.4.3
 pytest

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -7,6 +7,7 @@ See LICENSE for details
 from io import BytesIO
 from pghoard.common import get_object_storage_config
 from pghoard.rohmu import compat, errors, get_transfer
+from pghoard.rohmu.object_storage.google import MediaStreamUpload
 import datetime
 import hashlib
 import os
@@ -484,3 +485,13 @@ class RandomDataSource:
         data = self.data[self.bytes_returned:bytes_to_return + self.bytes_returned]
         self.bytes_returned += bytes_to_return
         return data
+
+
+def test_media_stream_upload_read():
+    bio = BytesIO(b"abcdefg")
+    msu = MediaStreamUpload(bio, chunk_size=1024, mime_type="application/octet-stream", name="foo")
+    assert msu.getbytes(0, 4) == b"abcd"
+    assert msu.getbytes(2, 6) == b"cdef"
+    assert msu.getbytes(2, 7) == b"cdefg"
+    with pytest.raises(IndexError):
+        msu.getbytes(0, 7)


### PR DESCRIPTION
Re-reading the same block of data or part of the block always failed.