### PR TITLE
rohmu: Fix GCS MediaStreamUpload

### DIFF
--- a/pghoard/rohmu/object_storage/google.py
+++ b/pghoard/rohmu/object_storage/google.py
@@ -415,8 +415,8 @@ class MediaStreamUpload(MediaUpload):
     def resumable(self):
         return True
 
-    def getbytes(self, begin, end):
-        length = end - begin
+    # second parameter is length but baseclass incorrectly names it end
+    def getbytes(self, begin, length):  # pylint: disable=arguments-differ
         if begin < (self._position or 0):
             msg = "Requested position {} for {!r} preceeds already fulfilled position {}".format(
                 begin, self._name, self._position

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -491,7 +491,7 @@ def test_media_stream_upload_read():
     bio = BytesIO(b"abcdefg")
     msu = MediaStreamUpload(bio, chunk_size=1024, mime_type="application/octet-stream", name="foo")
     assert msu.getbytes(0, 4) == b"abcd"
-    assert msu.getbytes(2, 6) == b"cdef"
-    assert msu.getbytes(2, 7) == b"cdefg"
+    assert msu.getbytes(2, 4) == b"cdef"
+    assert msu.getbytes(2, 5) == b"cdefg"
     with pytest.raises(IndexError):
         msu.getbytes(0, 7)


### PR DESCRIPTION
getbytes length parameter was named incorrectly causing earlier
attempt to fix invalid implementation to actually cause regression.