### PR TITLE
pghoard: ensure that verify_wal read from the beginning of file objects

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -11,6 +11,7 @@ disable=
     no-else-raise,
     no-else-return,
     no-self-use,
+    raise-missing-from,
     too-few-public-methods,
     too-many-ancestors,
     too-many-arguments,

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ coverage: $(generated)
 	$(PYTHON) -m coverage report --show-missing
 
 pylint: $(generated)
-	$(PYTHON) -m pylint.lint --rcfile .pylintrc $(PYTHON_SOURCE_DIRS)
+	$(PYTHON) -m pylint --rcfile .pylintrc $(PYTHON_SOURCE_DIRS)
 
 flake8: $(generated)
 	$(PYTHON) -m flake8 --exclude=__init__.py --ignore=E722 --max-line-len=125 $(PYTHON_SOURCE_DIRS)

--- a/pghoard/postgres_command.py
+++ b/pghoard/postgres_command.py
@@ -39,7 +39,7 @@ EXIT_ABORT = 255
 
 class PGCError(Exception):
     def __init__(self, message, exit_code=EXIT_FAIL):
-        super(PGCError, self).__init__(message)
+        super().__init__(message)
         self.exit_code = exit_code
 
 

--- a/pghoard/wal.py
+++ b/pghoard/wal.py
@@ -125,6 +125,7 @@ def verify_wal(*, wal_name, fileobj=None, filepath=None):
     try:
         if fileobj:
             pos = fileobj.tell()
+            fileobj.seek(0)
             header_bytes = fileobj.read(WAL_HEADER_LEN)
             fileobj.seek(pos)
             source_name = getattr(fileobj, "name", "<UNKNOWN>")

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ python-dateutil
 python-snappy
 python-systemd 
 requests
-azure-storage
-azure
+azure-storage-blob==2.1.0
 paramiko
 zstandard


### PR DESCRIPTION
When passing a file object to verify_wal, the header must always be read
from the beginning of the object.