### PR TITLE
fmt: Add yapf formatting and travis build configuration

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,55 @@
+[style]
+# For docs, see https://github.com/google/yapf/blob/master/README.rst
+
+based_on_style = pep8
+# Disallow splitting between dict key and dict value in multiline {"key": "value"} lines
+ALLOW_SPLIT_BEFORE_DICT_VALUE = false
+
+# Avoid adding unnecessary blank lines when nesting
+BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF = false
+
+# Always add two blank lines for top-level classes and methods
+BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION = 2
+
+# These two combine consecutive ({ and }) to same line to reduce clutter
+COALESCE_BRACKETS = true
+DEDENT_CLOSING_BRACKETS = true
+
+# Line length
+COLUMN_LIMIT = 125
+
+# Try to avoid having overly long lines by having excessively large penalty for that.
+SPLIT_PENALTY_EXCESS_CHARACTER = 1000000000
+
+# Always split dict entries to one entry per line
+# EACH_DICT_ENTRY_ON_SEPARATE_LINE = true
+
+# Never split this comment to a separate line. Workaround for certain flake8 & email template lines
+I18N_COMMENT = # noqa
+
+# Allow automatically joining lines, for example, multiline if that would fit to a single line
+JOIN_MULTIPLE_LINES = true
+
+# "3 * 5", instead of "3*5"
+SPACES_AROUND_POWER_OPERATOR = true
+
+# Follow normal comment style by adding two spaces between code and comment
+SPACES_BEFORE_COMMENT = 2
+
+# If list of items is comma terminated, always split to one per line.
+SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED = true
+
+# Related to previous one, if list of items (args or dict/list/...) needs to be split, split to one per line.
+# SPLIT_ALL_COMMA_SEPARATED_VALUES = true
+
+# Split dict generators for clarity (add line breaks between { and key: val etc.
+SPLIT_BEFORE_DICT_SET_GENERATOR = true
+
+# Split method(k1=v1, k2=v2...) to separate lines
+SPLIT_BEFORE_NAMED_ASSIGNS = true
+
+# For complex (for some definition of complex) comprehensions, put output, for and if to separate lines
+SPLIT_COMPLEX_COMPREHENSION = true
+
+# When splitting something to multiple lines ('method(\n val...'), intend by 4
+CONTINUATION_INDENT_WIDTH = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,27 @@ inc_unittest: &inc_unittest
   - make unittest
 
 jobs:
+  allow_failures:
+    # Don't require fmt to succeed until we have applied it
+    - stage: lint
+      name: fmt
+
   include:
     # Run linters with our "primary" Python version.
+    - stage: lint
+      python: 3.6
+      env: [PG_VERSION=9.6]
+      name: fmt
+      before_install: *inc_before_install
+      install: *inc_install
+      script:
+        - make fmt
+        - if [ $(git diff --name-only --diff-filter=ACMR | wc -l ) != 0 ]; then
+          echo "Reformatting failed! Please run make fmt on your commits and resubmit!" 1>&2 ;
+          git diff ;
+          exit 1 ;
+          fi
+
     - stage: lint
       python: 3.6
       env: [PG_VERSION=9.6]

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ unittest: version
 lint: version
 	$(PYTHON) -m pylint --rcfile .pylintrc $(PYTHON_SOURCE_DIRS)
 
+.PHONY: fmt
+fmt: version
+	unify --quote '"' --recursive --in-place $(PYTHON_SOURCE_DIRS)
+	isort --recursive $(PYTHON_SOURCE_DIRS)
+	yapf --parallel --recursive --in-place $(PYTHON_SOURCE_DIRS)
+
 .PHONY: coverage
 coverage: version
 	$(PYTHON) -m pytest $(PYTEST_ARG) --cov-report term-missing --cov pghoard test/

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -6,6 +6,9 @@ pytest
 pytest-mock
 pytest-timeout
 pytest-xdist
+yapf==0.27.0
+isort==4.3.21
 coverage
 coveralls
 responses
+unify


### PR DESCRIPTION
Add the standard `yapf` formatting configuration and validation to the travis build with formatting configured to allow failures.