### PR TITLE
pg: add support for PostgreSQL 13

### DIFF
--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -16,7 +16,7 @@ from pghoard.rohmu import get_class_for_transfer
 from pghoard.rohmu.errors import InvalidConfigurationError
 from pghoard.rohmu.snappyfile import snappy
 
-SUPPORTED_VERSIONS = ["12", "11", "10", "9.6", "9.5", "9.4", "9.3"]
+SUPPORTED_VERSIONS = ["13", "12", "11", "10", "9.6", "9.5", "9.4", "9.3"]
 
 
 def get_cpu_count():

--- a/pghoard/wal.py
+++ b/pghoard/wal.py
@@ -15,6 +15,7 @@ PARTIAL_WAL_RE = re.compile(r"^[A-F0-9]{24}\.partial$")
 TIMELINE_RE = re.compile(r"^[A-F0-9]{8}\.history$")
 WAL_RE = re.compile("^[A-F0-9]{24}$")
 WAL_HEADER_LEN = 20
+# Look at the file src/include/access/xlog_internal.h and grep for XLOG_PAGE_MAGIC
 WAL_MAGIC = {
     0xD071: 90200,  # Though PGHoard no longer supports version 9.2, magic number is left for WAL identification purposes
     0xD075: 90300,
@@ -24,6 +25,7 @@ WAL_MAGIC = {
     0xD097: 100000,
     0xD098: 110000,
     0xD101: 120000,
+    0xD106: 130000,
 }
 WAL_MAGIC_BY_VERSION = {value: key for key, value in WAL_MAGIC.items()}
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -130,6 +130,10 @@ def setup_pg():
             # don't need to wait for autovacuum workers when shutting down
             "autovacuum": "off",
         })
+        # Setting name has changed in PG 13, set comparison needed because 9.6 is somehow larger than 13 for the comparison
+        if db.pgver >= "13" and db.pgver not in {"9.5", "9.6"}:
+            del config["wal_keep_segments"]
+            config["wal_keep_size"] = 16 * 100
         lines = ["{} = {}\n".format(key, val) for key, val in sorted(config.items())]  # noqa
         fp.write("".join(lines))
     # now start pg and create test users


### PR DESCRIPTION
Changes needed this time round were mostly around postgreql.conf
replacing keep_wal_segments with with keep_wal_size and the WAL
version header bump.