### PR TITLE
make sure that level gets used for zstd

### DIFF
--- a/pghoard/rohmu/compressor.py
+++ b/pghoard/rohmu/compressor.py
@@ -32,7 +32,7 @@ def CompressionFile(dst_fp, algorithm, level=0, threads=0):
         return SnappyFile(dst_fp, "wb")
 
     if algorithm == "zstd":
-        return zstd_open(dst_fp, "wb", threads=threads)
+        return zstd_open(dst_fp, "wb", level=level, threads=threads)
 
     if algorithm:
         raise InvalidConfigurationError("invalid compression algorithm: {!r}".format(algorithm))


### PR DESCRIPTION
The CompressionStream in the rohmu/compressor.py is not used to do compression, its only use is in test cases.

The level param needs to be passed into the zstd_open instead, otherwise the default level of '0' is actually used.   

I double checked and a level of 0 is passed through to the zstandard package.   It results in slightly less compression than if level 3 was passed in.  **So pghoard zstd uses level 0 compression at the moment.**

My PR is a very small change to make sure the level is getting passed in, to make it possible to actually specify a compression level.