### PR TITLE
azure: Use azure-sdk instead of azure-storage-python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,5 +63,5 @@ build-dep-fed:
 		python3-botocore python3-cryptography python3-paramiko python3-dateutil python3-devel \
 		python3-flake8 python3-psycopg2 python3-pylint python3-pytest \
 		python3-pytest-cov python3-requests python3-snappy \
-		python3-azure-storage \
+		python3-azure-sdk \
 		rpm-build

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ The following Python modules are required:
 
 Optional requirements include:
 
-* azure_ for Microsoft Azure object storage
+* azure_ for Microsoft Azure object storage (patched version required, see link)
 * botocore_ for AWS S3 (or Ceph-S3) object storage
 * google-api-client_ for Google Cloud object storage
 * cryptography_ for backup encryption and decryption (version 0.8 or newer required)
@@ -100,7 +100,7 @@ Optional requirements include:
 * swiftclient_ for OpenStack Swift object storage
 * paramiko_  for sftp object storage
 
-.. _`azure`: https://github.com/Azure/azure-sdk-for-python
+.. _`azure`: https://github.com/aiven/azure-sdk-for-python/tree/aiven/rpm_fixes
 .. _`botocore`: https://github.com/boto/botocore
 .. _`google-api-client`: https://github.com/google/google-api-python-client
 .. _`cryptography`: https://cryptography.io/

--- a/pghoard/rohmu/object_storage/azure.py
+++ b/pghoard/rohmu/object_storage/azure.py
@@ -5,19 +5,21 @@ Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
 import time
+from io import BytesIO
 
 # pylint: disable=import-error, no-name-in-module
 import azure.common
-from azure.storage.blob import BlockBlobService, ContentSettings
-from azure.storage.blob.models import BlobPrefix
+from azure.core.exceptions import ResourceExistsError
+from azure.storage.blob import BlobServiceClient, ContentSettings
+from azure.storage.blob._models import BlobPrefix, BlobType
 
 from ..errors import (FileNotFoundFromStorageError, InvalidConfigurationError, StorageError)
 from .base import (KEY_TYPE_OBJECT, KEY_TYPE_PREFIX, BaseTransfer, IterKeyItem, get_total_memory)
 
 ENDPOINT_SUFFIXES = {
-    None: None,  # use default
+    None: "core.windows.net",
     "germany": "core.cloudapi.de",  # Azure Germany is a completely separate cloud from the regular Azure Public cloud
-    "public": None,  # use default
+    "public": "core.windows.net"
 }
 
 
@@ -31,7 +33,7 @@ def calculate_max_block_size():
 # files. Default block size is set to 4 MiB so only ~200 GB files can be uploaded. In order to get close
 # to that 5 TiB increase the block size based on host memory; we don't want to use the max 100 for all
 # hosts because the uploader will allocate (with default settings) 3 x block size of memory.
-BlockBlobService.MAX_BLOCK_SIZE = calculate_max_block_size()
+MAX_BLOCK_SIZE = calculate_max_block_size()
 
 
 class AzureTransfer(BaseTransfer):
@@ -46,8 +48,15 @@ class AzureTransfer(BaseTransfer):
         except KeyError:
             raise InvalidConfigurationError("Unknown azure cloud {!r}".format(azure_cloud))
 
-        self.conn = BlockBlobService(
-            account_name=self.account_name, account_key=self.account_key, endpoint_suffix=endpoint_suffix
+        conn_str = (
+            "DefaultEndpointsProtocol=https;"
+            f"AccountName={self.account_name};"
+            f"AccountKey={self.account_key};"
+            f"EndpointSuffix={endpoint_suffix}"
+        )
+        self.conn = BlobServiceClient.from_connection_string(
+            conn_str=conn_str,
+            max_block_size=MAX_BLOCK_SIZE,
         )
         self.conn.socket_timeout = 120  # Default Azure socket timeout 20s is a bit short
         self.container = self.get_or_create_container(self.container_name)
@@ -57,19 +66,22 @@ class AzureTransfer(BaseTransfer):
         timeout = kwargs.get("timeout") or 15
         source_path = self.format_key_for_backend(source_key, remove_slash_prefix=True, trailing_slash=False)
         destination_path = self.format_key_for_backend(destination_key, remove_slash_prefix=True, trailing_slash=False)
-        source_url = self.conn.make_blob_url(self.container_name, source_path)
+        source_client = self.conn.get_blob_client(self.container_name, source_path)
+        destination_client = self.conn.get_blob_client(self.container_name, destination_path)
+        source_url = source_client.url
         start = time.monotonic()
-        self.conn.copy_blob(self.container_name, destination_path, source_url, metadata=metadata, timeout=timeout)
+
+        destination_client.start_copy_from_url(source_url, metadata=metadata, timeout=timeout)
         while True:
-            blob_properties = self.conn.get_blob_properties(self.container_name, destination_path, timeout=timeout)
-            copy_props = blob_properties.properties.copy
+            blob_properties = destination_client.get_blob_properties(timeout=timeout)
+            copy_props = blob_properties.copy
             if copy_props.status == "success":
                 return
             elif copy_props.status == "pending":
                 if time.monotonic() - start < timeout:
                     time.sleep(0.1)
                 else:
-                    self.conn.abort_copy_blob(self.container_name, destination_key, copy_props.id, timeout=timeout)
+                    destination_client.abort_copy(copy_props.id, timeout=timeout)
                     raise StorageError(
                         "Copying {!r} to {!r} did not complete in {} seconds".format(source_key, destination_key, timeout)
                     )
@@ -104,29 +116,33 @@ class AzureTransfer(BaseTransfer):
 
     def _iter_key(self, *, path, with_metadata, deep):
         include = "metadata" if with_metadata else None
-        kwargs = {}
+        container_client = self.conn.get_container_client(self.container_name)
+        name_starts_with = None
+        delimiter = ""
         if path:
             # If you give Azure an empty path, it gives you an authentication error
-            kwargs["prefix"] = path
+            name_starts_with = path
         if not deep:
-            kwargs["delimiter"] = "/"
-        items = self.conn.list_blobs(self.container_name, include=include, **kwargs)
+            delimiter = "/"
+        items = container_client.walk_blobs(include=include, name_starts_with=name_starts_with, delimiter=delimiter)
         for item in items:
             if isinstance(item, BlobPrefix):
                 yield IterKeyItem(type=KEY_TYPE_PREFIX, value=self.format_key_from_backend(item.name).rstrip("/"))
             else:
                 if with_metadata:
-                    # Azure Storage cannot handle '-' so we turn them into underscores and back again
-                    metadata = {k.replace("_", "-"): v for k, v in item.metadata.items()}
+                    metadata = {}
+                    if item.metadata:
+                        # Azure Storage cannot handle '-' so we turn them into underscores and back again
+                        metadata = {k.replace("_", "-"): v for k, v in item.metadata.items()}
                 else:
                     metadata = None
                 yield IterKeyItem(
                     type=KEY_TYPE_OBJECT,
                     value={
-                        "last_modified": item.properties.last_modified,
+                        "last_modified": item.last_modified,
                         "metadata": metadata,
                         "name": self.format_key_from_backend(item.name),
-                        "size": item.properties.content_length,
+                        "size": item.size,
                     },
                 )
 
@@ -134,8 +150,9 @@ class AzureTransfer(BaseTransfer):
         key = self.format_key_for_backend(key, remove_slash_prefix=True)
         self.log.debug("Deleting key: %r", key)
         try:
-            return self.conn.delete_blob(self.container_name, key)
-        except azure.common.AzureMissingResourceHttpError as ex:  # pylint: disable=no-member
+            blob_client = self.conn.get_blob_client(container=self.container_name, blob=key)
+            return blob_client.delete_blob()
+        except azure.core.exceptions.ResourceNotFoundError as ex:  # pylint: disable=no-member
             raise FileNotFoundFromStorageError(key) from ex
 
     def get_contents_to_file(self, key, filepath_to_store_to, *, progress_callback=None):
@@ -143,8 +160,10 @@ class AzureTransfer(BaseTransfer):
 
         self.log.debug("Starting to fetch the contents of: %r to: %r", key, filepath_to_store_to)
         try:
-            self.conn.get_blob_to_path(self.container_name, key, filepath_to_store_to)
-        except azure.common.AzureMissingResourceHttpError as ex:  # pylint: disable=no-member
+            with open(filepath_to_store_to, "wb") as f:
+                container_client = self.conn.get_container_client(self.container_name)
+                container_client.download_blob(key).readinto(f)
+        except azure.core.exceptions.ResourceNotFoundError as ex:  # pylint: disable=no-member
             raise FileNotFoundFromStorageError(key) from ex
 
         if progress_callback:
@@ -165,29 +184,30 @@ class AzureTransfer(BaseTransfer):
         allows reading entire blob into memory at once or returning data from random offsets"""
         file_size = None
         start_range = 0
-        chunk_size = self.conn.MAX_CHUNK_GET_SIZE
+        chunk_size = self.conn._config.max_chunk_get_size  # pylint: disable=protected-access
         end_range = chunk_size - 1
+        blob = self.conn.get_blob_client(self.container_name, key)
         while True:
             try:
                 # pylint: disable=protected-access
-                blob = self.conn._get_blob(self.container_name, key, start_range=start_range, end_range=end_range)
+                download_stream = blob.download_blob(offset=start_range, length=chunk_size)
                 if file_size is None:
-                    file_size = self._parse_length_from_content_range(blob.properties.content_range)
-                fileobj.write(blob.content)
-                start_range += blob.properties.content_length
-                if start_range == file_size:
+                    file_size = download_stream._file_size
+                download_stream.readinto(fileobj)
+                start_range += download_stream.size
+                if start_range >= file_size:
                     break
-                if blob.properties.content_length == 0:
+                if download_stream.size == 0:
                     raise StorageError("Empty response received for {}, range {}-{}".format(key, start_range, end_range))
-                end_range += blob.properties.content_length
+                end_range += download_stream.size
                 if end_range >= file_size:
                     end_range = file_size - 1
                 if progress_callback:
                     progress_callback(start_range, file_size)
-            except azure.common.AzureHttpError as ex:  # pylint: disable=no-member
+            except azure.core.exceptions.ResourceNotFoundError as ex:  # pylint: disable=no-member
                 if ex.status_code == 416:  # Empty file
                     return
-                raise
+                raise FileNotFoundFromStorageError(key) from ex
 
     def get_contents_to_fileobj(self, key, fileobj_to_store_to, *, progress_callback=None):
         key = self.format_key_for_backend(key, remove_slash_prefix=True)
@@ -195,29 +215,30 @@ class AzureTransfer(BaseTransfer):
         self.log.debug("Starting to fetch the contents of: %r", key)
         try:
             self._stream_blob(key, fileobj_to_store_to, progress_callback)
-        except azure.common.AzureMissingResourceHttpError as ex:  # pylint: disable=no-member
+        except azure.core.exceptions.ResourceNotFoundError as ex:  # pylint: disable=no-member
             raise FileNotFoundFromStorageError(key) from ex
 
         if progress_callback:
             progress_callback(1, 1)
-
         return self._metadata_for_key(key)
 
     def get_contents_to_string(self, key):
         key = self.format_key_for_backend(key, remove_slash_prefix=True)
         self.log.debug("Starting to fetch the contents of: %r", key)
         try:
-            blob = self.conn.get_blob_to_bytes(self.container_name, key)
-            return blob.content, self._metadata_for_key(key)
-        except azure.common.AzureMissingResourceHttpError as ex:  # pylint: disable=no-member
+            container_client = self.conn.get_container_client(self.container_name)
+            blob = BytesIO()
+            container_client.download_blob(key).download_to_stream(blob)
+            return blob.getvalue(), self._metadata_for_key(key)
+        except azure.core.exceptions.ResourceNotFoundError as ex:  # pylint: disable=no-member
             raise FileNotFoundFromStorageError(key) from ex
 
     def get_file_size(self, key):
         key = self.format_key_for_backend(key, remove_slash_prefix=True)
         try:
-            blob = self.conn.get_blob_properties(self.container_name, key)
-            return blob.properties.content_length
-        except azure.common.AzureMissingResourceHttpError as ex:  # pylint: disable=no-member
+            blob_client = self.conn.get_blob_client(self.container_name, key)
+            return blob_client.get_blob_properties().size
+        except azure.core.exceptions.ResourceNotFoundError as ex:  # pylint: disable=no-member
             raise FileNotFoundFromStorageError(key) from ex
 
     def store_file_from_memory(self, key, memstring, metadata=None, cache_control=None, mimetype=None):
@@ -227,12 +248,13 @@ class AzureTransfer(BaseTransfer):
         content_settings = None
         if mimetype:
             content_settings = ContentSettings(content_type=mimetype)
-        self.conn.create_blob_from_bytes(
-            self.container_name,
-            key,
-            bytes(memstring),  # azure would work with memoryview, but validates it's bytes
+        blob_client = self.conn.get_blob_client(self.container_name, key)
+        blob_client.upload_blob(
+            bytes(memstring),
+            blob_type=BlobType.BlockBlob,
             content_settings=content_settings,
-            metadata=self.sanitize_metadata(metadata, replace_hyphen_with="_")
+            metadata=self.sanitize_metadata(metadata, replace_hyphen_with="_"),
+            overwrite=True
         )
 
     def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
@@ -242,13 +264,15 @@ class AzureTransfer(BaseTransfer):
         content_settings = None
         if mimetype:
             content_settings = ContentSettings(content_type=mimetype)
-        self.conn.create_blob_from_path(
-            self.container_name,
-            key,
-            filepath,
-            content_settings=content_settings,
-            metadata=self.sanitize_metadata(metadata, replace_hyphen_with="_")
-        )
+        with open(filepath, "rb") as data:
+            blob_client = self.conn.get_blob_client(self.container_name, key)
+            blob_client.upload_blob(
+                data,
+                blob_type=BlobType.BlockBlob,
+                content_settings=content_settings,
+                metadata=self.sanitize_metadata(metadata, replace_hyphen_with="_"),
+                overwrite=True
+            )
 
     def store_file_object(self, key, fd, *, cache_control=None, metadata=None, mimetype=None, upload_progress_fn=None):
         if cache_control is not None:
@@ -258,8 +282,9 @@ class AzureTransfer(BaseTransfer):
         if mimetype:
             content_settings = ContentSettings(content_type=mimetype)
 
-        def progress_callback(bytes_sent, _):
-            if upload_progress_fn:
+        def progress_callback(pipeline_response):
+            bytes_sent = pipeline_response.context["upload_stream_current"]
+            if upload_progress_fn and bytes_sent:
                 upload_progress_fn(bytes_sent)
 
         # Azure _BlobChunkUploader calls `tell()` on the stream even though it doesn't use the result.
@@ -269,13 +294,14 @@ class AzureTransfer(BaseTransfer):
             original_tell = getattr(fd, "tell", None)
             fd.tell = lambda: None
         try:
-            self.conn.create_blob_from_stream(
-                self.container_name,
-                key,
+            blob_client = self.conn.get_blob_client(self.container_name, key)
+            blob_client.upload_blob(
                 fd,
+                blob_type=BlobType.BlockBlob,
                 content_settings=content_settings,
                 metadata=self.sanitize_metadata(metadata, replace_hyphen_with="_"),
-                progress_callback=progress_callback
+                raw_response_hook=progress_callback,
+                overwrite=True
             )
         finally:
             if not seekable:
@@ -286,6 +312,9 @@ class AzureTransfer(BaseTransfer):
 
     def get_or_create_container(self, container_name):
         start_time = time.monotonic()
-        self.conn.create_container(container_name)
+        try:
+            self.conn.create_container(container_name)
+        except ResourceExistsError:
+            pass
         self.log.debug("Got/Created container: %r successfully, took: %.3fs", container_name, time.monotonic() - start_time)
         return container_name


### PR DESCRIPTION
azure-storage-python depends on deprecated packages in fedora33 and is no longer actively maintained

We are building this from our own fork of `python3-azure-sdk` to incorporate the changes mentioned by Rauli below. 
Changes can be found here: https://github.com/aiven/azure-sdk-for-python/tree/aiven/rpm_fixes