### PR TITLE
azure: Reduce logging verbocity of http_logging_policy

### DIFF
--- a/pghoard/rohmu/object_storage/azure.py
+++ b/pghoard/rohmu/object_storage/azure.py
@@ -4,6 +4,7 @@ rohmu - azure object store interface
 Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
+import logging
 import time
 from io import BytesIO
 
@@ -34,6 +35,10 @@ def calculate_max_block_size():
 # to that 5 TiB increase the block size based on host memory; we don't want to use the max 100 for all
 # hosts because the uploader will allocate (with default settings) 3 x block size of memory.
 MAX_BLOCK_SIZE = calculate_max_block_size()
+
+
+# Reduce Azure logging verbocity of http requests and responses
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
 
 
 class AzureTransfer(BaseTransfer):


### PR DESCRIPTION
This should turn off the detailed logging of every http request and response.

```
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO: Request method: 'PUT'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO: Request headers:
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'Content-Type': 'application/octet-stream'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'Content-Length': '1133'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-version': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-blob-type': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-meta-pg_version': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-meta-compression_algorithm': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-meta-compression_level': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-meta-original_file_size': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-meta-host': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-meta-hash': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-meta-hash_algorithm': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-meta-encryption_key_id': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-date': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-client-request-id': '25ec5d1c-5659-11eb-8131-0022489a8b8d'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'User-Agent': 'azsdk-python-storage-blob/12.3.1 Python/3.7.9 (Linux-5.8.18-100.fc31.x86_64-x86_64-with-fedora-31-Thirty_One)'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'Authorization': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO: Response status: 201
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO: Response headers:
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'Content-Length': '0'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'Content-MD5': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'Last-Modified': 'Thu, 14 Jan 2021 11:10:45 GMT'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'ETag': '"0x8D8B87D0A21E3E0"'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'Server': 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-request-id': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-client-request-id': '25ec5d1c-5659-11eb-8131-0022489a8b8d'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-version': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-content-crc64': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'x-ms-request-server-encrypted': 'REDACTED'
Jan 14 11:10:45 foo-test-n1008 pghoard[12118]: azure.core.pipeline.policies.http_logging_policy Thread-6 INFO:     'Date': 'Thu, 14 Jan 2021 11:10:45 GMT'
```