### PR TITLE
test: fix parsing negative timezone offsets

### DIFF
--- a/test/test_rohmu_dates.py
+++ b/test/test_rohmu_dates.py
@@ -5,6 +5,7 @@ Copyright (c) 2017 Ohmu Ltd
 See LICENSE for details
 """
 import datetime
+import re
 
 import dateutil.tz
 
@@ -14,8 +15,10 @@ from pghoard.rohmu.dates import parse_timestamp
 def test_parse_timestamp():
     local_aware = datetime.datetime.now(dateutil.tz.tzlocal())
 
-    str_local_aware_naive = local_aware.isoformat().split("+", 1)[0]
-    str_local_aware_named = "{} {}".format(str_local_aware_naive, local_aware.tzname())
+    # split local_aware such as "2021-02-08T09:58:27.988218-05:00" into date, time, tzoffset components
+    str_date, str_localtime_aware = local_aware.isoformat().split("T", 1)
+    str_localtime_naive = re.split("[+-]", str_localtime_aware, maxsplit=1)[0]
+    str_local_aware_named = "{}T{} {}".format(str_date, str_localtime_naive, local_aware.tzname())
 
     assert parse_timestamp(str_local_aware_named) == local_aware
     local_naive = parse_timestamp(str_local_aware_named, with_tz=False, assume_local=True)


### PR DESCRIPTION
The unit test `test_parse_timestamp` currently fails for local timestamps whose timezone is in a western timezone, that is, local time has an offset negative from UTC like UTC-05:00.