### PR TITLE
Properly handle fetcher pool when exiting

### DIFF
--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -547,6 +547,10 @@ class BasebackupFetcher():
                     with self.pool_class(processes=self._process_count()) as pool:
                         self._queue_jobs(pool)
                         self._wait_for_jobs_to_complete()
+                        # Context manager does not seem to properly wait for the subprocesses to exit, let's join
+                        # the pool manually (close need to be called before joining)
+                        pool.close()
+                        pool.join()
                         break
             except TimeoutError:
                 self.pending_jobs.clear()


### PR DESCRIPTION
Context manager of multiprocess pool in fetcher does not seem to properly wait for the subprocesses to exit, let's join the pool manually (close need to be called before joining).
It looks like when pool gets destroyed, sometimes all the processes get SIGTERM (including the main process), which is not a desired behavior, we want to wait for the pool to finish its job and then quit properly.

It might potentially lead to an inconsistent state of restoration.