### PR TITLE
Add basebackup mode with delta statistics [BF-356]

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -28,7 +28,7 @@ disable=
 
 [FORMAT]
 max-line-length=125
-max-module-lines=1000
+max-module-lines=1100
 
 [REPORTS]
 output-format=text

--- a/README.rst
+++ b/README.rst
@@ -690,6 +690,16 @@ tablespaces.
 Note that the ``local-tar`` backup mode can not be used on replica servers
 prior to PostgreSQL 9.6 unless the pgespresso extension is installed.
 
+When using ``delta`` mode, only changed files are uploaded into the storage.
+On every backup snapshot of the data files is taken, this results in a manifest file,
+describing the hashes of all the files needed to be backed up.
+New hashes are uploaded to the storage and used together with complementary
+manifest from control file for restoration.
+In order to properly assess the efficiency of ``delta`` mode in comparison with
+``local-tar``, one can use ``local-tar-delta-stats`` mode, which behaves the same as
+``local-tar``, but also collects the metrics as if it was ``delta`` mode. It can help
+in decision making of switching to ``delta`` mode.
+
 ``basebackup_threads`` (default ``1``)
 
 How many threads to use for tar, compress and encrypt tasks. Only applies for

--- a/pghoard/common.py
+++ b/pghoard/common.py
@@ -42,6 +42,7 @@ class BaseBackupMode(StrEnum):
     basic = "basic"
     delta = "delta"
     local_tar = "local-tar"
+    local_tar_delta_stats = "local-tar-delta-stats"
     pipe = "pipe"
 
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,6 @@
 # Use pip for build requirements to harmonize between OS versions
 mock
-pylint>=2.4.3
+pylint>=2.4.3,<=2.7.2
 pylint-quotes
 pytest
 pytest-mock

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -362,6 +362,9 @@ LABEL: pg_basebackup base backup
     def test_basebackups_delta(self, capsys, db, pghoard, tmpdir):
         self._test_basebackups(capsys, db, pghoard, tmpdir, BaseBackupMode.delta)
 
+    def test_basebackups_local_tar_with_delta_stats(self, capsys, db, pghoard, tmpdir):
+        self._test_basebackups(capsys, db, pghoard, tmpdir, BaseBackupMode.local_tar_delta_stats)
+
     def test_basebackups_local_tar_nonexclusive(self, capsys, db, pghoard, tmpdir):
         if db.pgver < "9.6":
             pytest.skip("PostgreSQL 9.6+ required for non-exclusive backups")


### PR DESCRIPTION
Add `local-tar-delta-stats` basebackup mode, which behaves the same as
`local-tar` mode, but adds some statistics as if it was a `delta` mode, so
these numbers can be used to support a decision if switching the delta mode
makes sense.