### PR TITLE
swift: add hash to object result

### DIFF
--- a/pghoard/rohmu/object_storage/swift.py
+++ b/pghoard/rohmu/object_storage/swift.py
@@ -152,6 +152,7 @@ class SwiftTransfer(BaseTransfer):
                         "size": item["bytes"] + segments_size,
                         "last_modified": last_modified,
                         "metadata": metadata,
+                        "hash": item.get("hash"),
                     },
                 )
 


### PR DESCRIPTION
sample output result from listing an object:

{'bytes': 4245, 'last_modified': '2021-05-13T20:37:32.959340', 'hash': '5aa70b19655a26a7ec4edf926..', 'name': 'alxric/testfile.ini', 'content_type': 'application/octet-stream'}