### PR TITLE
handle exceptions in compressor threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /.pydevproject
 /.vagrant
 /.idea
+/.vscode
 __pycache__/
 /build/
 /dist/


### PR DESCRIPTION
On failed compression, the compressor thread would just jump to the next data in the queue after reporting an error.

Instead, make sure that a few retries are conducted on the same event just in case, and exit if it keeps failing.