### PR TITLE
swift: Do not delete succesfull file downloads

### DIFF
--- a/pghoard/rohmu/object_storage/swift.py
+++ b/pghoard/rohmu/object_storage/swift.py
@@ -189,13 +189,16 @@ class SwiftTransfer(BaseTransfer):
 
     def get_contents_to_file(self, key, filepath_to_store_to, *, progress_callback=None):
         temp_filepath = "{}~".format(filepath_to_store_to)
+        done = False
         with open(temp_filepath, "wb") as fp:
             try:
                 metadata = self.get_contents_to_fileobj(key, fp, progress_callback=progress_callback)
                 os.rename(temp_filepath, filepath_to_store_to)
+                done = True
             finally:
                 with suppress(FileNotFoundError):
-                    os.unlink(filepath_to_store_to)
+                    if not done:
+                        os.unlink(filepath_to_store_to)
         return metadata
 
     def get_contents_to_fileobj(self, key, fileobj_to_store_to, *, progress_callback=None):


### PR DESCRIPTION
This function has been puzzling me for a large part of the evening, so it's possible that I am missing something here, but as far as I read this, this function can never do anything useful in it's current state.

It will regardless of what happens always immediately delete the file again right after completing the download, leaving you with nothing.

But then again, original code has been there since 2016, so it's very likely me missing something here