### PR TITLE
rohmu/google: HttpError when streaming perfectly aligned file

### DIFF
--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -519,3 +519,16 @@ def test_media_stream_upload_read():
     assert msu.getbytes(2, 5) == b"cdefg"
     with pytest.raises(IndexError):
         msu.getbytes(0, 7)
+
+
+def test_media_stream_upload_read_aligned_size():
+    b = b"abcdefghijklmnopqr"
+    bio = BytesIO(b)
+    msu = MediaStreamUpload(bio, chunk_size=6, mime_type="application/octet-stream", name="foo")
+    assert msu.size() is None
+    assert msu.getbytes(0, 6) == b[:6]
+    assert msu.size() is None
+    assert msu.getbytes(6, 6) == b[6:12]
+    assert msu.size() == len(b)
+    assert msu.getbytes(12, 6) == b[12:]
+    assert msu.size() == len(b)


### PR DESCRIPTION
When doing streaming upload, a `*` can be used for the total file size
in the `Content-Range` header of intermediate chunks. But the total
file size should be provided in the final chunk so that the uploading
can be finalized. Add a `peek` method into `MediaStreamUpload` so that
we can return the total file size when reading the fianl chunk.