### PR TITLE
Fix missing WAL files [BF-585]

### DIFF
--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -8,13 +8,15 @@ import hashlib
 import logging
 import os
 import socket
+import time
 from io import BytesIO
 from queue import Empty, Queue
 from tempfile import NamedTemporaryFile
 from threading import Event, Thread
-from typing import Dict, Optional
+from typing import Dict, Optional, Set
 
-from pghoard import config, wal
+from pghoard import config as pgh_config
+from pghoard import wal
 from pghoard.common import write_json_file
 from pghoard.metrics import Metrics
 from pghoard.rohmu import errors, rohmufile
@@ -31,6 +33,7 @@ class CompressorThread(Thread):
         transfer_queue: Queue,
         metrics: Metrics,
         critical_failure_event: Event,
+        wal_file_deletion_queue: Queue,
     ):
         super().__init__()
         self.log = logging.getLogger("Compressor")
@@ -39,6 +42,7 @@ class CompressorThread(Thread):
         self.state = {}
         self.compression_queue = compression_queue
         self.transfer_queue = transfer_queue
+        self.wal_file_deletion_queue = wal_file_deletion_queue
         self.running = True
         self.critical_failure_event = critical_failure_event
         self.log.debug("Compressor initialized")
@@ -136,7 +140,7 @@ class CompressorThread(Thread):
                 input_obj=BytesIO(event["blob"]),
                 output_obj=output_obj,
                 metadata=event.get("metadata"),
-                key_lookup=config.key_lookup_for_site(self.config, event["site"]),
+                key_lookup=pgh_config.key_lookup_for_site(self.config, event["site"]),
                 log_func=self.log.debug,
             )
 
@@ -239,7 +243,16 @@ class CompressorThread(Thread):
             transfer_object["local_path"] = event["full_path"]
 
         if event.get("delete_file_after_compression", True):
-            os.unlink(event["full_path"])
+            if filetype == "xlog":
+                delete_request = {
+                    "type": "delete_file",
+                    "site": site,
+                    "local_path": event["full_path"],
+                }
+                self.log.info("Adding to Uncompressed WAL file to deletion queue: %s", event["full_path"])
+                self.wal_file_deletion_queue.put(delete_request)
+            else:
+                os.unlink(event["full_path"])
 
         self.transfer_queue.put(transfer_object)
         return True
@@ -263,3 +276,82 @@ class CompressorThread(Thread):
                     "count": 0
                 },
             }
+
+
+class WALFileDeleterThread(Thread):
+    """Deletes files which got compressed by the Compressor Thread, but keeps one file around
+
+    pg_receivewal, after some hickup, will use the files to compute the next wal segment to download.
+    if there are none, it will start at the current server position and so might miss wal segments. This
+    would mean that the backup is incomplete until the next base backup is taken and the service would
+    fail to be restored.
+
+    So the idea is to only unlink all files but the latest one.
+    """
+    def __init__(
+        self,
+        config: Dict,
+        wal_file_deletion_queue: Queue,
+        metrics: Metrics,
+    ):
+        super().__init__()
+        self.log = logging.getLogger("WALFileDeleter")
+        self.config = config
+        self.metrics = metrics
+        self.wal_file_deletion_queue = wal_file_deletion_queue
+        self.running = True
+        self.to_be_deleted_files: Dict[str, Set[str]] = {}
+        self.log.debug("WALFileDeleter initialized")
+
+    def run(self):
+        while self.running:
+            wait_timeout = 1.0
+            # config can be changed in another thread, so we have to lookup this within the loop
+            config_wait_timeout = self.config.get("deleter_event_get_timeout", wait_timeout)
+            try:
+                # prevent bad formats killing the thread
+                wait_timeout = float(config_wait_timeout)
+            except ValueError:
+                self.log.warning("Bad value for deleter_event_get_timeout: %r", config_wait_timeout)
+
+            try:
+                event = self.wal_file_deletion_queue.get(timeout=wait_timeout)
+            except Empty:
+                continue
+
+            try:
+                if event["type"] == "QUIT":
+                    break
+                if event["type"] == "delete_file":
+                    site = event["site"]
+                    local_path = event["local_path"]
+                    if site not in self.to_be_deleted_files:
+                        self.to_be_deleted_files[site] = set()
+                    self.to_be_deleted_files[site].add(local_path)
+                else:
+                    raise RuntimeError("Received bad event")
+                self.deleted_unneeded_files()
+            except Exception as ex:  # pylint: disable=broad-except
+                self.log.exception("Problem handling event %r: %s: %s", event, ex.__class__.__name__, ex)
+                self.metrics.unexpected_exception(ex, where="wal_file_deleter_run")
+                # Don't block the whole CPU in case something is persistently crashing
+                time.sleep(0.1)
+                # If we have a problem, just keep running for now, at the worst we accumulate files
+                continue
+
+        self.log.debug("Quitting WALFileDeleter")
+
+    def deleted_unneeded_files(self):
+        """Deletes all but the latest file in the current list of files"""
+        for site, to_be_deleted_files_per_site in self.to_be_deleted_files.items():
+            if len(to_be_deleted_files_per_site) <= 1:
+                # Nothing to do (yet)
+                continue
+            for file in sorted(to_be_deleted_files_per_site)[:-1]:
+                try:
+                    os.unlink(file)
+                    self.log.info("Deleted uncompressed WAL file: %s", file)
+                except FileNotFoundError as ex:
+                    self.log.exception("WAL file does not exist: site %s, file %s", site, file)
+                    self.metrics.unexpected_exception(ex, where="wal_file_deleter_delete_unneeded_files")
+                to_be_deleted_files_per_site.remove(file)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -207,7 +207,8 @@ def pghoard_separate_volume(db, tmpdir, request):
     # environments where sudo can be executed without password prompts.
     try:
         subprocess.check_call(
-            ["sudo", "-S", "mount", "-t", "tmpfs", "-o", "size=100m", "tmpfs", tmpfs_volume],
+            # We need 150MB because we keep at least one wal file around, 100MB is too small
+            ["sudo", "-S", "mount", "-t", "tmpfs", "-o", "size=150m", "tmpfs", tmpfs_volume],
             stdin=subprocess.DEVNULL,
         )
     except subprocess.CalledProcessError as ex:
@@ -285,6 +286,8 @@ def pghoard_base(
         # is separate test case that executes the multiprocess version.
         "restore_process_count": 1,
         "tar_executable": "tar",
+        # to speed up the tests
+        "deleter_event_get_timeout": 0.01,
     }
 
     if metrics_cfg is not None:

--- a/test/test_compressor.py
+++ b/test/test_compressor.py
@@ -83,6 +83,7 @@ class CompressionCase(PGHoardTestCase):
         })
         self.compression_queue = Queue()
         self.transfer_queue = Queue()
+        self.wal_file_deletion_queue = Queue()
         self.incoming_path = os.path.join(
             self.config["backup_location"],
             self.config["backup_sites"][self.test_site]["prefix"],
@@ -102,6 +103,7 @@ class CompressionCase(PGHoardTestCase):
             transfer_queue=self.transfer_queue,
             metrics=metrics.Metrics(statsd={}),
             critical_failure_event=Event(),
+            wal_file_deletion_queue=self.wal_file_deletion_queue
         )
         self.compressor.start()
 
@@ -239,12 +241,14 @@ class CompressionCase(PGHoardTestCase):
     )
     def test_compress_error_retry(self, side_effects, is_failure):
         compression_queue = Queue()
+        wal_file_deletion_queue = Queue()
         test_compressor = CompressorThread(
             config_dict=self.config,
             compression_queue=compression_queue,
             transfer_queue=Queue(),
             metrics=metrics.Metrics(statsd={}),
             critical_failure_event=Event(),
+            wal_file_deletion_queue=wal_file_deletion_queue
         )
         test_compressor.MAX_FAILED_RETRY_ATTEMPTS = 2
         test_compressor.RETRY_INTERVAL = 0

--- a/test/test_wal_file_deleter.py
+++ b/test/test_wal_file_deleter.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+
+import time
+from queue import Queue
+
+import mock
+import pytest
+
+from pghoard import metrics
+from pghoard.compressor import WALFileDeleterThread
+
+
+# too fool the
+class WALFileDeleterThreadPatched(WALFileDeleterThread):
+    os_unlink_mock: mock.MagicMock
+
+
+@pytest.fixture(name="wal_file_deleter")
+def fixture_wal_file_deleter(mocker):
+    deleter_queue = Queue()
+    # speed up the tests
+    config = {"deleter_event_get_timeout": 0.001}
+    deleter = WALFileDeleterThread(
+        config=config,
+        wal_file_deletion_queue=deleter_queue,
+        metrics=metrics.Metrics(statsd={}),
+    )
+    os_unlink_mock = mock.MagicMock()
+    mocker.patch("os.unlink", side_effect=os_unlink_mock)
+    deleter.os_unlink_mock = os_unlink_mock
+    deleter.start()
+    yield deleter
+    deleter.running = False
+    deleter_queue.put({"type": "QUIT"})
+    deleter.join()
+
+
+def make_event(path: str, site: str = "a"):
+    return {
+        "type": "delete_file",
+        "site": site,
+        "local_path": path,
+    }
+
+
+TEST_WAIT_TIME = 0.1
+
+
+def test_wal_file_deleter_happy_path(wal_file_deleter: WALFileDeleterThreadPatched):
+
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001"))
+    time.sleep(TEST_WAIT_TIME)
+    assert len(wal_file_deleter.to_be_deleted_files["a"]) == 1
+    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000001"}
+    wal_file_deleter.os_unlink_mock.assert_not_called()
+
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000002"))
+    time.sleep(TEST_WAIT_TIME)
+    assert len(wal_file_deleter.to_be_deleted_files["a"]) == 1
+    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000002"}
+    wal_file_deleter.os_unlink_mock.assert_called_once_with("AA000001")
+
+    wal_file_deleter.os_unlink_mock.reset_mock()
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001"))
+    time.sleep(TEST_WAIT_TIME)
+    assert len(wal_file_deleter.to_be_deleted_files["a"]) == 1
+    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000002"}
+    wal_file_deleter.os_unlink_mock.assert_called_once_with("AA000001")
+
+    # Even if there are multiple files in the list, we delete all but the latest
+    wal_file_deleter.os_unlink_mock.reset_mock()
+    wal_file_deleter.to_be_deleted_files["a"].add("AA000004")
+    wal_file_deleter.to_be_deleted_files["a"].add("AA000003")
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001"))
+    time.sleep(TEST_WAIT_TIME)
+    assert len(wal_file_deleter.to_be_deleted_files["a"]) == 1
+    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000004"}
+    assert wal_file_deleter.os_unlink_mock.call_count == 3
+
+
+def test_survive_problems(wal_file_deleter: WALFileDeleterThreadPatched):
+
+    # We survive a non-existing local_path attribute
+    wal_file_deleter.wal_file_deletion_queue.put({
+        "type": "delete_file",
+        "site": "a",
+        "local_path_MISSING": "path",
+    })
+    time.sleep(TEST_WAIT_TIME)
+    assert len(wal_file_deleter.to_be_deleted_files) == 0
+    assert wal_file_deleter.running
+
+    # we have to have a type
+    wal_file_deleter.wal_file_deletion_queue.put({
+        "type_MISSING": "delete_file",
+        "site": "a",
+        "local_path": "AA000001",
+    })
+    time.sleep(TEST_WAIT_TIME)
+    assert wal_file_deleter.running
+    assert len(wal_file_deleter.to_be_deleted_files) == 0
+
+    # the type does matter
+    wal_file_deleter.wal_file_deletion_queue.put({
+        "type": "DOES MATTER",
+        "site": "a",
+        "local_path": "AA000001",
+    })
+    time.sleep(TEST_WAIT_TIME)
+    assert wal_file_deleter.running
+    assert len(wal_file_deleter.to_be_deleted_files) == 0
+
+    # site must not be missing
+    wal_file_deleter.wal_file_deletion_queue.put({
+        "type": "delete_file",
+        "site_MISSING": "a",
+        "local_path": "AA000001",
+    })
+    time.sleep(TEST_WAIT_TIME)
+    assert wal_file_deleter.running
+    assert len(wal_file_deleter.to_be_deleted_files) == 0
+
+    # Adding the same path twice will still result in that file not deleted
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001"))
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001"))
+    time.sleep(TEST_WAIT_TIME)
+    assert wal_file_deleter.running
+    wal_file_deleter.os_unlink_mock.assert_not_called()
+    assert len(wal_file_deleter.to_be_deleted_files["a"]) == 1
+    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000001"}
+
+    # we survive not finding the file during deletion and the to be deleted ("older") file is still removed from the queue
+    wal_file_deleter.os_unlink_mock.side_effect = FileNotFoundError("foo")
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000002"))
+    time.sleep(TEST_WAIT_TIME)
+    assert wal_file_deleter.running
+    assert len(wal_file_deleter.to_be_deleted_files["a"]) == 1
+    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000002"}
+
+
+def test_multiple_sites(wal_file_deleter: WALFileDeleterThreadPatched):
+
+    # Adding the same path twice will still result in that file not deleted
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001", site="a"))
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001", site="b"))
+    time.sleep(TEST_WAIT_TIME)
+    assert wal_file_deleter.running
+    wal_file_deleter.os_unlink_mock.assert_not_called()
+    assert len(wal_file_deleter.to_be_deleted_files) == 2
+    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000001"}
+    assert wal_file_deleter.to_be_deleted_files["b"] == {"AA000001"}
+
+    # advance one site
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000002", site="a"))
+    time.sleep(TEST_WAIT_TIME)
+    assert wal_file_deleter.running
+    assert wal_file_deleter.os_unlink_mock.call_count == 1
+    assert len(wal_file_deleter.to_be_deleted_files) == 2
+    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000002"}
+    assert wal_file_deleter.to_be_deleted_files["b"] == {"AA000001"}
+
+    # Should do nothing
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001", site="b"))
+    time.sleep(TEST_WAIT_TIME)
+    assert wal_file_deleter.running
+    assert wal_file_deleter.os_unlink_mock.call_count == 1
+    assert len(wal_file_deleter.to_be_deleted_files) == 2
+    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000002"}
+    assert wal_file_deleter.to_be_deleted_files["b"] == {"AA000001"}
+
+    # now advance it on site b
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000003", site="b"))
+    time.sleep(TEST_WAIT_TIME)
+    assert wal_file_deleter.running
+    #assert wal_file_deleter.os_unlink_mock.call_count == 2
+    assert len(wal_file_deleter.to_be_deleted_files) == 2
+    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000002"}
+    assert wal_file_deleter.to_be_deleted_files["b"] == {"AA000003"}
+
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001", site="c"))
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000002", site="c"))
+    wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000003", site="c"))
+    time.sleep(TEST_WAIT_TIME)
+    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000002"}
+    assert wal_file_deleter.to_be_deleted_files["b"] == {"AA000003"}
+    assert wal_file_deleter.to_be_deleted_files["c"] == {"AA000003"}


### PR DESCRIPTION
In rare circumstances (probably involving high load), the compressor thread would finish and unlink a WAL file before pg_receivewal would have ran fsync on it. That would trigger a reconnect in pg_receivewal which would mean that pg_receivewal would start from the current server position (because it would only look for files in the directory to figure out the next WAL segment to pull, but all the files are already gone). That in case could mean, if the WAL position would already have advanced enough, that we miss uploading WAL segments leading to a non-recoverable backup from that position onwards until the next basebackup.

The fixes for this:
* [x] Keep the latest WAL file around per site to let pg_receivewal start from that position -> this is fixing the root cause
* [x] ~~Check that a file is not anymore in use by pg_receivewal before unlinking it -> fixing the trigger~~ makes no sense: the order of events is close file as `*.partial`, rename to actual, open file, fsync, close file. The fix relied on the assumtion that the file would be open after rename...
* [x] ~~Make pg10+ use "on file close" as trigger to process the WAL file and not "on file rename" -> fixing the trigger~~ -> deferred to after pg9.x is EOL

-> The root cause should be fixed by the first commit and also preventing the trigger, as we wait until the next file is ready until delting the earlier on. An additional fix for starting the whole compression on file close and not file will be done after PG 9.x is EOL.  