### PR TITLE
wait for wals setting for local tar base backups

### DIFF
--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -730,6 +730,7 @@ class PGBaseBackup(Thread):
         temp_base_dir, compressed_base = self.get_paths_for_backup(self.basebackup_path)
         os.makedirs(compressed_base)
         data_file_format = "{}/{}.{{0:08d}}.pghoard".format(compressed_base, os.path.basename(compressed_base)).format
+        wait_for_wals = self.config["backup_sites"][self.site]["basebackup_wait_for_wals"]
 
         # Default to 2GB chunks of uncompressed data
         target_chunk_size = self.site_config["basebackup_chunk_size"]
@@ -882,7 +883,7 @@ class PGBaseBackup(Thread):
 
                 # Call the stop backup functions now to get backup label for 9.6+ non-exclusive backups
                 if backup_mode == "non-exclusive":
-                    cursor.execute("SELECT labelfile FROM pg_stop_backup(false)")
+                    cursor.execute("SELECT labelfile FROM pg_stop_backup(false, %s)", [wait_for_wals])
                     backup_label = cursor.fetchone()[0]
                 elif backup_mode == "pgespresso":
                     cursor.execute("SELECT pgespresso_stop_backup(%s)", [backup_label])
@@ -907,7 +908,7 @@ class PGBaseBackup(Thread):
                 db_conn.rollback()
                 if not backup_stopped:
                     if backup_mode == "non-exclusive":
-                        cursor.execute("SELECT pg_stop_backup(false)")
+                        cursor.execute("SELECT pg_stop_backup(false, %s)", [wait_for_wals])
                     elif backup_mode == "pgespresso":
                         cursor.execute("SELECT pgespresso_stop_backup(%s)", [backup_label])
                     else:

--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -82,6 +82,7 @@ def set_and_check_config_defaults(config, *, check_commands=True, check_pgdata=T
 
         site_config.setdefault("basebackup_chunk_size", 1024 * 1024 * 1024 * 2)
         site_config.setdefault("basebackup_chunks_in_progress", 5)
+        site_config.setdefault("basebackup_wait_for_wals", True)
         site_config.setdefault("basebackup_compression_threads", 0)
         site_config.setdefault("basebackup_count", 2)
         site_config.setdefault("basebackup_count_min", 2)


### PR DESCRIPTION
Its useful to not wait for all wals when using pg_stop_backup, especially for databases that don't get a lot of activity.   We already switch wal / xlog after this code anyway.