### PR TITLE
Remove aivenisms

### DIFF
--- a/test/base.py
+++ b/test/base.py
@@ -52,7 +52,9 @@ class PGHoardTestCase:
         # NOTE: we set pg_receivexlog_path and pg_basebackup_path per site and globally mostly to verify that
         # it works, the config keys are deprecated and will be removed in a future release at which point we'll
         # switch to using pg_bin_directory config.
-        bindir, ver = find_pg_binary("")
+        pgexe, ver = find_pg_binary("postgres")
+        if pgexe is not None:
+            bindir = os.path.dirname(pgexe)
 
         if hasattr(psycopg2.extras, "PhysicalReplicationConnection"):
             active_backup_mode = "walreceiver"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -91,7 +91,8 @@ def setup_pg():
     # try to find the binaries for these versions in some path
     pgdata = os.path.join(tmpdir, "pgdata")
     db = PGTester(pgdata)  # pylint: disable=redefined-outer-name
-    db.run_cmd("initdb", "-D", pgdata, "--encoding", "utf-8")
+    db.run_cmd("initdb", "-D", pgdata, "--encoding", "utf-8",
+               "--lc-messages=C")
     # NOTE: does not use TCP ports, no port conflicts
     db.user = dict(host=pgdata, user="pghoard", password="pghoard", dbname="postgres", port="5432")
     # NOTE: point $HOME to tmpdir - $HOME shouldn't affect most tests, but

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -36,8 +36,9 @@ logutil.configure_logging()
 class PGTester:
     def __init__(self, pgdata):
         pgver = os.getenv("PG_VERSION")
-        pgbin, ver = pghconfig.find_pg_binary("", versions=[pgver] if pgver else None)
-        self.pgbin = pgbin
+        postgresbin, ver = pghconfig.find_pg_binary("postgres", versions=[pgver] if pgver else None)
+        if postgresbin is not None:
+            self.pgbin = os.path.dirname(postgresbin)
         self.ver = ver
         self.pgdata = pgdata
         self.pg = None
@@ -91,8 +92,7 @@ def setup_pg():
     # try to find the binaries for these versions in some path
     pgdata = os.path.join(tmpdir, "pgdata")
     db = PGTester(pgdata)  # pylint: disable=redefined-outer-name
-    db.run_cmd("initdb", "-D", pgdata, "--encoding", "utf-8",
-               "--lc-messages=C")
+    db.run_cmd("initdb", "-D", pgdata, "--encoding", "utf-8", "--lc-messages=C")
     # NOTE: does not use TCP ports, no port conflicts
     db.user = dict(host=pgdata, user="pghoard", password="pghoard", dbname="postgres", port="5432")
     # NOTE: point $HOME to tmpdir - $HOME shouldn't affect most tests, but

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -178,7 +178,7 @@ def recovery_db():
             "recovery_target_timeline = 'latest'",
             "restore_command = 'false'",
         ]
-        if LooseVersion(pg.ver) >= "12":
+        if LooseVersion(pg.pgver) >= "12":
             with open(os.path.join(pg.pgdata, "standby.signal"), "w") as fp:
                 pass
 

--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -309,7 +309,7 @@ class TestWebServer:
             "recovery_target_timeline = 'latest'",
             "restore_command = 'false'",
         ]
-        if LooseVersion(db.ver) >= "12":
+        if LooseVersion(db.pgver) >= "12":
             with open(os.path.join(db.pgdata, "standby.signal"), "w") as fp:
                 pass
 


### PR DESCRIPTION
This PR aims to make it easier to run pghoard and it's tests in different environments.

- pghoard depends on PostgreSQL being setup with lc_messages=C so at least specify it correctly in the tests initdb run.
- rework the way find_pg_binary works so that it can work on non DEB / RPM systems more consistently
- make a consistent use of PGTester.pgver instead of PGTester.ver: PGTester.pgver is the actual version of the PGDATA directory while PGTester.ver is the "wanted" version. 
- also support "devel" versioning scheme when working with a not-yet-released PostgreSQL