### PR TITLE
add active-backup-mode to metadata for base backups

### DIFF
--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -336,6 +336,7 @@ class PGBaseBackup(Thread):
         metadata.update({
             "original-file-size": original_input_size,
             "pg-version": self.pg_version_server,
+            "active-backup-mode": self.site_config["active_backup_mode"],
         })
         metadata.update(self.metadata)
 
@@ -399,6 +400,7 @@ class PGBaseBackup(Thread):
                 **self.metadata,
                 "start-time": start_time,
                 "start-wal-segment": start_wal_segment,
+                "active-backup-mode": self.site_config["active_backup_mode"],
             },
             "type": "CLOSE_WRITE",
         })
@@ -949,6 +951,7 @@ class PGBaseBackup(Thread):
                 "end-time": backup_end_time,
                 "end-wal-segment": backup_end_wal_segment,
                 "pg-version": self.pg_version_server,
+                "active-backup-mode": self.site_config["active_backup_mode"],
                 "start-time": backup_start_time,
                 "start-wal-segment": backup_start_wal_segment,
                 "total-size-plain": total_size_plain,

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -267,6 +267,8 @@ LABEL: pg_basebackup base backup
                 assert "end-time" in backup["metadata"]
                 assert dateutil.parser.parse(backup["metadata"]["end-time"]).tzinfo  # pylint: disable=no-member
 
+            assert backups[0]["metadata"]["active-backup-mode"] == active_backup_mode
+
     def _test_restore_basebackup(self, db, pghoard, tmpdir, active_backup_mode="archive_command"):
         backup_out = tmpdir.join("test-restore").strpath
         # Restoring to empty directory works


### PR DESCRIPTION
Useful to have metadata field when using standalone base backup