### PR TITLE
update Vagrantfile to ubuntu 20.04 and support python 3.6-3.9 and PostgreSQL 9.6-12

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,26 +123,46 @@ should work on other platforms that provide the required modules.
 Vagrant
 =======
 
-The Vagrantfile can be used to setup a vagrant development environment, consisting of two
-vagrant virtual machines.
+The Vagrantfile can be used to setup a vagrant development environment.   The vagrant environment has
+python 3.6, 3.7, 3.8 and 3.9 virtual environments and installations of postgresql 9.6, 10, 11 and 12.
 
-1) Postgresql 9.4, python 3.5 and 3.6::
+By default vagrant up will start a Virtualbox environment.   The Vagrantfile will also work for libvirt, just prefix
+VAGRANT_DEFAULT_PROVIDER=libvirt to the vagrant up command.
 
-    vagrant up
-    vagrant ssh postgres9
-    cd /vagrant
-    source ~/venv3/bin/activate
-    make test
-    source ~/venv3.6/bin/activate
-    make test
+Any combination of Python (3.6, 3.7 and 3.8) and Postgresql (9.6, 10, 11 and 12)
 
-2) Postgresql 10 and python 3.7::
+Bring up vagrant instance and connect via ssh::
 
-    vagrant ssh postgres10
-    cd /vagrant
-    make test
+vagrant up
+vagrant ssh
+vagrant@ubuntu2004:~$ cd /vagrant
 
-Note: make deb does not work from vagrant at the moment, hopefully this will be resolved soon
+Test with Python 3.6 and Postgresql 9.6
+
+vagrant@ubuntu2004:~$ source ~/venv3.6/bin/activate
+vagrant@ubuntu2004:~$ PG_VERSION=9.6 make unittest
+vagrant@ubuntu2004:~$ deactivate
+
+Test with Python 3.7 and Postgresql 10
+
+vagrant@ubuntu2004:~$ source ~/venv3.7/bin/activate
+vagrant@ubuntu2004:~$ PG_VERSION=10 make unittest
+vagrant@ubuntu2004:~$ deactivate
+
+Test with Python 3.8 and Postgresql 11
+
+vagrant@ubuntu2004:~$ source ~/venv3.8/bin/activate
+vagrant@ubuntu2004:~$ PG_VERSION=11 make unittest
+vagrant@ubuntu2004:~$ deactivate
+
+Test with Python 3.9 and Postgresql 12
+
+vagrant@ubuntu2004:~$ source ~/venv3.9/bin/activate
+vagrant@ubuntu2004:~$ PG_VERSION=12 make unittest
+vagrant@ubuntu2004:~$ deactivate
+
+And so on
+
 
 Building
 ========

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,16 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+unless system("sudo -n true 2> /dev/null")
+    puts('Sudo is required, do a sudo true')
+    exit
+end
+
+# to be able to modify tests outside of vagrant, we use nfs mount point, for more
+# information refer https://www.vagrantup.com/docs/synced-folders/nfs
 Vagrant.configure("2") do |config|
-    config.vm.box = "ubuntu/xenial64"
+    config.vm.box = "generic/ubuntu2004"
+    config.vm.synced_folder ".", "/vagrant", type: "nfs"
 
     $script = <<-SCRIPT
         ssh-keyscan localhost >> ~/.ssh/known_hosts
@@ -11,12 +19,28 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", inline: $script, privileged: false
 
     $script = <<-SCRIPT
-        echo "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+        export DEBIAN_FRONTEND="noninteractive"
+
+        # optionally enable use of ng apt cacher on the host
+        export NG_PROXY_URL="#{ENV['NG_PROXY_URL']}"
+        if [ "$NG_PROXY_URL" != "" ]; then
+            echo "Enabling Apt Proxy ($NG_PROXY_URL) ..."
+            echo 'Acquire::http { Proxy "$NG_PROXY_URL"; };' > /etc/apt/apt.conf.d/02proxy
+        fi
+
+        echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
         add-apt-repository -y ppa:deadsnakes/ppa
 
         apt-get update
-        apt-get install -y build-essential libsnappy-dev
+        apt-get install -y build-essential libsnappy-dev postgresql-common
+
+        # no point creating the default cluster as its not used for tests
+        sed -i "s/^#start_conf.*/start_conf='manual'/g" /etc/postgresql-common/createcluster.conf
+        sed -i "s/^#create_main_cluster.*/create_main_cluster=false/g" /etc/postgresql-common/createcluster.conf
+
+        apt-get install -y python3.6 python3.6-dev python3.6-venv python3.7 python3.7-dev python3.7-venv python3.8 python3.8-dev python3.8-venv python3.9 python3.9-dev python3.9-venv
+        apt-get install -y postgresql-9.6 postgresql-server-dev-9.6 postgresql-10 postgresql-server-dev-10 postgresql-11 postgresql-server-dev-11 postgresql-12 postgresql-server-dev-12
 
         username="$(< /dev/urandom tr -dc a-z | head -c${1:-32};echo;)"
         password=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32};echo;)
@@ -31,52 +55,28 @@ Vagrant.configure("2") do |config|
 
         sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
 
+        # later versions have the Port 22 config disabled (cos its the default), so need to
+        # explicitly enable it to avoid ssh only using port 23.
+        echo "Port 22" >> /etc/ssh/sshd_config
+
+        # this is for sftp testing
         echo "Port 23" >> /etc/ssh/sshd_config
         echo "Match LocalPort 22" >> /etc/ssh/sshd_config
         echo "	DenyUsers $username" >> /etc/ssh/sshd_config
         systemctl reload ssh
     SCRIPT
+
     config.vm.provision "shell", inline: $script, privileged: true
 
-    config.vm.define "postgres9" do |postgres9|
-        postgres9.vm.hostname = "postgres9.test"
-
-        $script = <<-SCRIPT
-            apt-get install -y postgresql-9.4 postgresql-server-dev-9.4 python3 python3-dev python3-venv python3.6 python3.6-dev python3.6-venv
-        SCRIPT
-        postgres9.vm.provision "shell", inline: $script, privileged: true
-
-        $script = <<-SCRIPT
-            versions=(3 3.6)
-            for version in "${versions[@]}"; do
-                python${version} -m venv venv${version}
-                source ~/venv${version}/bin/activate
-                pip install --upgrade pip
-                pip install astroid==2.0.0 cryptography paramiko botocore flake8 httplib2 mock psycopg2 pylint==2.2.2 pytest python-dateutil python-snappy python-systemd requests azure-storage
-            done
-
-            echo "source ~/venv3/bin/activate" >> ~/.bashrc
-        SCRIPT
-        postgres9.vm.provision "shell", inline: $script, privileged: false
-    end
-
-    config.vm.define "postgres10" do |postgres10|
-        postgres10.vm.hostname = "postgres10.test"
-
-        $script = <<-SCRIPT
-            apt-get install -y postgresql-10 postgresql-server-dev-10 python3.7 python3.7-dev python3.7-venv
-        SCRIPT
-        postgres10.vm.provision "shell", inline: $script, privileged: true
-
-        $script = <<-SCRIPT
-            python3.7 -m venv venv3.7
-            source ~/venv3.7/bin/activate
+    $script = <<-SCRIPT
+        versions=(3.6 3.7 3.8 3.9)
+        for version in "${versions[@]}"; do
+            python${version} -m venv venv${version}
+            source ~/venv${version}/bin/activate
             pip install --upgrade pip
-            pip install astroid==2.0.0 cryptography paramiko botocore flake8 httplib2 mock psycopg2 pylint==2.2.2 pytest python-dateutil python-snappy python-systemd requests azure-storage
-
-            echo "source ~/venv3.7/bin/activate" >> ~/.bashrc
-
-        SCRIPT
-        postgres10.vm.provision "shell", inline: $script, privileged: false
-    end
+            pip install -r /vagrant/requirements.txt
+            pip install --upgrade -r /vagrant/requirements.dev.txt
+        done
+    SCRIPT
+    config.vm.provision "shell", inline: $script, privileged: false
 end

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -47,28 +47,47 @@ PGHoard has been developed and tested on modern Linux x86-64 systems, but
 should work on other platforms that provide the required modules.
 
 Vagrant
--------
+=======
 
-The Vagrantfile can be used to setup a vagrant development environment, consisting of two
-vagrant virtual machines.
+The Vagrantfile can be used to setup a vagrant development environment.   The vagrant environment has
+python 3.6, 3.7, 3.8 and 3.9 virtual environments and installations of postgresql 9.6, 10, 11 and 12.
 
-1) Postgresql 9.4, python 3.5 and 3.6::
+By default vagrant up will start a Virtualbox environment.   The Vagrantfile will also work for libvirt, just prefix
+VAGRANT_DEFAULT_PROVIDER=libvirt to the vagrant up command.
 
-    vagrant up
-    vagrant ssh postgres9
-    cd /vagrant
-    source ~/venv3/bin/activate
-    make test
-    source ~/venv3.6/bin/activate
-    make test
+Any combination of Python (3.6, 3.7 and 3.8) and Postgresql (9.6, 10, 11 and 12)
 
-2) Postgresql 10 and python 3.7::
+Bring up vagrant instance and connect via ssh::
 
-    vagrant ssh postgres10
-    cd /vagrant
-    make test
+vagrant up
+vagrant ssh
+vagrant@ubuntu2004:~$ cd /vagrant
 
-Note: make deb does not work from vagrant at the moment, hopefully this will be resolved soon
+Test with Python 3.6 and Postgresql 9.6
+
+vagrant@ubuntu2004:~$ source ~/venv3.6/bin/activate
+vagrant@ubuntu2004:~$ PG_VERSION=9.6 make unittest
+vagrant@ubuntu2004:~$ deactivate
+
+Test with Python 3.7 and Postgresql 10
+
+vagrant@ubuntu2004:~$ source ~/venv3.7/bin/activate
+vagrant@ubuntu2004:~$ PG_VERSION=10 make unittest
+vagrant@ubuntu2004:~$ deactivate
+
+Test with Python 3.8 and Postgresql 11
+
+vagrant@ubuntu2004:~$ source ~/venv3.8/bin/activate
+vagrant@ubuntu2004:~$ PG_VERSION=11 make unittest
+vagrant@ubuntu2004:~$ deactivate
+
+Test with Python 3.9 and Postgresql 12
+
+vagrant@ubuntu2004:~$ source ~/venv3.9/bin/activate
+vagrant@ubuntu2004:~$ PG_VERSION=12 make unittest
+vagrant@ubuntu2004:~$ deactivate
+
+And so on
 
 .. _building_from_source:
 


### PR DESCRIPTION
supports python 3.6-3.9 and PostgreSQL 9.6-12