### PR TITLE
fix issue with prometheus

### DIFF
--- a/pghoard/monitoring/prometheus.py
+++ b/pghoard/monitoring/prometheus.py
@@ -38,8 +38,8 @@ class PrometheusClient:
     def _update(self, metric, value, tags):
         ts = str(int(time.time())) + "000"
 
-        metric = metric.replace(".", "_")
-        tags = {**self._tags, **tags}
+        metric = metric.replace(".", "_").replace("-", "_")
+        tags = {**self._tags, **tags} if tags else {**self._tags}
         tag_list = []
         for k in sorted(tags.keys()):
             tag_list.append("{}=\"{}\"".format(k, tags[k]))


### PR DESCRIPTION
…error because **tags is None

This line in basebackup.py breaks prometheus parsing when using local-tar:

```
"pghoard.backup_time_{}".format(self.site_config["basebackup_mode"]),
```