### PR TITLE
Fix last_flushed_lsn computation

### DIFF
--- a/pghoard/wal.py
+++ b/pghoard/wal.py
@@ -68,6 +68,14 @@ def name_to_tli_log_seg(name):
     return (tli, log, seg)
 
 
+def lsn_of_next_wal_start(lsn: int):
+    """
+    Compute the LSN of the start of the wal segment after the one which
+    contains the given LSN.
+    """
+    return (lsn + WAL_SEG_SIZE) & 0xFFFF0000
+
+
 def get_previous_wal_on_same_timeline(seg, log, pg_version):
     if seg == 0:
         log -= 1
@@ -104,6 +112,11 @@ def lsn_from_name(name):
     _, log, seg = name_to_tli_log_seg(name)
     pos = seg * WAL_SEG_SIZE
     return "{:X}/{:X}".format(log, pos)
+
+
+def lsn_int_from_str(str_lsn):
+    log_hex, seg_hex = str_lsn.split("/", 1)
+    return int(log_hex, 16) + (int(seg_hex, 16) >> 24) * WAL_SEG_SIZE
 
 
 def construct_wal_name(sysinfo):

--- a/test/test_wal.py
+++ b/test/test_wal.py
@@ -65,6 +65,16 @@ def test_construct_wal_name():
     assert wal.construct_wal_name(sysinfo) == "000000040000000F00000019"
 
 
+def test_lsn_of_next_wal_start():
+    lsn_str = "0/10000AB"
+    lsn_int = wal.lsn_int_from_str(lsn_str)
+    assert lsn_int == 16777216
+    lsn_start = wal.get_lsn_from_start_of_wal_file(lsn_str)
+    assert lsn_start == "0/1000000"
+    next_wal_start_lsn = wal.lsn_of_next_wal_start(lsn_int)
+    assert next_wal_start_lsn == 33554432
+
+
 def test_verify_wal(tmpdir):
     b = BytesIO(WAL_HEADER_95 + b"XXX" * 100)
     with pytest.raises(wal.LsnMismatchError) as excinfo:


### PR DESCRIPTION
The last_flushed_lsn corresponded to the start of the wal file. This
means that we resume from the wal file which was already archived.

Instead, record the start position of the next wal file  to advance both
the replication slot and keep our internal state.

Additionally, move the completed LSN processing to it's own method, and
call it when we stop the thread (mostly useful for tests at the moment).

There is still the problem that the last_flushed_lsn is stored only in
the json state file.