### PR TITLE
Improved basic standalone base backup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -327,6 +327,10 @@ in the relevant site, for example::
 For more information refer to the postgresql documentation
 https://www.postgresql.org/docs/9.5/continuous-archiving.html#BACKUP-STANDALONE
 
+If configured with a basebackup_mode of 'pipe' standalone hot backups will not use replication slots.
+If configured with 'basic' or 'basic_gzip' basebackup_mode, then standalone hot backup will be executed with
+the -X fetch option, which will use a temporary replication slot  (pghoard currently does not support
+using a configured replication slot for base backups).
 
 Restoring databases
 ===================
@@ -674,12 +678,16 @@ set.
 
 The way basebackups should be created.  The default mode, ``basic`` runs
 ``pg_basebackup`` and waits for it to write an uncompressed tar file on the
-disk before compressing and optionally encrypting it.  The alternative mode
-``pipe`` pipes the data directly from ``pg_basebackup`` to PGHoard's
-compression and encryption processing reducing the amount of temporary disk
-space that's required.
+disk before compressing and optionally encrypting it.  A ``basic-gzip`` mode
+is also available and behaves exactly the same as ``basic`` except it waits
+for ``pg_basebackup`` to write a gzip compressed tar file, which is useful
+for situations where there is insufficient disk space for an uncompressed
+backup file (especially useful for basic standalone hot backup).  The
+alternative mode ``pipe`` pipes the data directly from ``pg_basebackup`` to
+PGHoard's compression and encryption processing reducing the amount of
+temporary disk space that's required.
 
-Neither ``basic`` nor ``pipe`` modes support multiple tablespaces.
+Neither ``basic``, ``basic-gzip`` or ``pipe`` modes support multiple tablespaces.
 
 Setting ``basebackup_mode`` to ``local-tar`` avoids using ``pg_basebackup``
 entirely when ``pghoard`` is running on the same host as the database.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -275,6 +275,12 @@ basebackup_mode (default ``"basic"``)
   ``basic``
     runs ``pg_basebackup`` and waits for it to write an uncompressed tar file on the
     disk before compressing and optionally encrypting it.
+
+  ``basic-gzip``
+    runs ``pg_basebackup`` and waits for it to write an gzip compressed tar file on the
+    disk before compressing and optionally encrypting it.    This mode is especially
+    useful if doing standalone base backups and there is insufficient disk space for
+    an uncompressed base backup.
   ``pipe``
     pipes the data directly from ``pg_basebackup`` to PGHoard's
     compression and encryption processing reducing the amount of temporary disk

--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -142,8 +142,8 @@ class PGBaseBackup(Thread):
     def run(self):
         try:
             basebackup_mode = self.site_config["basebackup_mode"]
-            if basebackup_mode == BaseBackupMode.basic:
-                self.run_basic_basebackup()
+            if basebackup_mode in {BaseBackupMode.basic, BaseBackupMode.basic_gzip}:
+                self.run_basic_basebackup(basebackup_mode)
             elif basebackup_mode == BaseBackupMode.local_tar:
                 self.run_local_tar_basebackup()
             elif basebackup_mode == BaseBackupMode.delta:
@@ -185,7 +185,7 @@ class PGBaseBackup(Thread):
                     return raw_basebackup, compressed_basebackup
             i += 1
 
-    def get_command_line(self, output_name):
+    def get_command_line(self, output_name, basebackup_mode):
         command = [
             self.site_config["pg_basebackup_path"],
             "--format",
@@ -197,32 +197,45 @@ class PGBaseBackup(Thread):
             output_name,
         ]
 
+        if basebackup_mode == BaseBackupMode.basic_gzip:
+            command.extend(["--gzip"])
+
+        wal_method = "none"
         if self.site_config["active_backup_mode"] == "standalone_hot_backup":
-            if self.pg_version_server >= 100000:
-                command.extend(["--wal-method=fetch"])
-            else:
-                command.extend(["--xlog-method=fetch"])
-        elif self.pg_version_server >= 100000:
-            command.extend(["--wal-method=none"])
+            wal_method = "stream" if output_name != "-" else "fetch"
+
+        if self.pg_version_server >= 100000:
+            command.extend(["--wal-method=" + wal_method])
+        else:
+            command.extend(["--xlog-method=" + wal_method])
 
         connection_string, _ = replication_connection_string_and_slot_using_pgpass(self.connection_info)
         command.extend(["--progress", "--dbname", connection_string])
 
         return command
 
-    def check_command_success(self, proc, output_file):
+    def check_command_success(self, proc, *output_files):
         rc = terminate_subprocess(proc, log=self.log)
         msg = "Ran: {!r}, took: {:.3f}s to run, returncode: {}".format(
             proc.args,
             time.monotonic() - proc.basebackup_start_time, rc
         )
-        if rc == 0 and os.path.exists(output_file):
-            self.log.info(msg)
-            return True
 
-        if output_file:
-            with suppress(FileNotFoundError):
-                os.unlink(output_file)
+        if rc == 0:
+            for output_file in output_files:
+                found_all = True
+                if not os.path.exists(output_file):
+                    self.log.error("Missing file %s", [output_file])
+                    found_all = False
+            if found_all:
+                self.log.info(msg)
+                return True
+
+        if output_files:
+            for output_file in output_files:
+                with suppress(FileNotFoundError):
+                    os.unlink(output_file)
+
         raise BackupFailure(msg)
 
     def basebackup_compression_pipe(self, proc, basebackup_path):
@@ -294,7 +307,7 @@ class PGBaseBackup(Thread):
         start_wal_segment = wal.get_current_wal_from_identify_system(connection_string)
 
         temp_basebackup_dir, compressed_basebackup = self.get_paths_for_backup(self.basebackup_path)
-        command = self.get_command_line("-")
+        command = self.get_command_line("-", BaseBackupMode.pipe)
         self.log.debug("Starting to run: %r", command)
         proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         setattr(proc, "basebackup_start_time", time.monotonic())
@@ -337,6 +350,7 @@ class PGBaseBackup(Thread):
             "original-file-size": original_input_size,
             "pg-version": self.pg_version_server,
             "active-backup-mode": self.site_config["active_backup_mode"],
+            "basebackup-mode": self.site_config["basebackup_mode"],
         })
         metadata.update(self.metadata)
 
@@ -364,14 +378,16 @@ class PGBaseBackup(Thread):
         return start_wal_segment, start_time
 
     def parse_backup_label_in_tar(self, basebackup_path):
-        with tarfile.TarFile(name=basebackup_path, mode="r") as tar:
+        with tarfile.open(name=basebackup_path, mode="r:gz" if "tar.gz" in basebackup_path else "r") as tar:
             content = tar.extractfile("backup_label").read()  # pylint: disable=no-member
         return self.parse_backup_label(content)
 
-    def run_basic_basebackup(self):
+    def run_basic_basebackup(self, basebackup_mode):
         basebackup_directory, _ = self.get_paths_for_backup(self.basebackup_path)
-        basebackup_tar_file = os.path.join(basebackup_directory, "base.tar")
-        command = self.get_command_line(basebackup_directory)
+        basebackup_file_extension = "tar.gz" if basebackup_mode == BaseBackupMode.basic_gzip else "tar"
+        basebackup_tar_filename = "base." + basebackup_file_extension
+        basebackup_tar_file = os.path.join(basebackup_directory, basebackup_tar_filename)
+        command = self.get_command_line(basebackup_directory, basebackup_mode)
 
         self.log.debug("Starting to run: %r", command)
         proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -390,18 +406,43 @@ class PGBaseBackup(Thread):
                     self.latest_activity = datetime.datetime.utcnow()
             if proc.poll() is not None:
                 break
-        self.check_command_success(proc, basebackup_tar_file)
+
+        if self.site_config["active_backup_mode"] == "standalone_hot_backup":
+            if self.pg_version_server >= 100000:
+                basebackup_wal_file = os.path.join(basebackup_directory, "pg_wal." + basebackup_file_extension)
+            else:
+                basebackup_wal_file = os.path.join(basebackup_directory, "pg_xlog." + basebackup_file_extension)
+            self.check_command_success(proc, basebackup_tar_file, basebackup_wal_file)
+
+            self.compression_queue.put({
+                "full_path": basebackup_wal_file,
+                "metadata": {
+                    "format": BaseBackupFormat.standalone_bb_xlogs,
+                    "pg-version": self.pg_version_server,
+                    "basebackup-mode": self.site_config["basebackup_mode"],
+                },
+                "type": "CLOSE_WRITE",
+            })
+        else:
+            self.check_command_success(proc, basebackup_tar_file)
 
         start_wal_segment, start_time = self.parse_backup_label_in_tar(basebackup_tar_file)
+        metadata = {
+            **self.metadata,
+            "start-time": start_time,
+            "start-wal-segment": start_wal_segment,
+            "pg-version": self.pg_version_server,
+            "active-backup-mode": self.site_config["active_backup_mode"],
+            "basebackup-mode": self.site_config["basebackup_mode"],
+        }
+
+        if self.site_config["active_backup_mode"] == "standalone_hot_backup":
+            metadata.update({"format": BaseBackupFormat.standalone})
+
         self.compression_queue.put({
             "callback_queue": self.callback_queue,
             "full_path": basebackup_tar_file,
-            "metadata": {
-                **self.metadata,
-                "start-time": start_time,
-                "start-wal-segment": start_wal_segment,
-                "active-backup-mode": self.site_config["active_backup_mode"],
-            },
+            "metadata": metadata,
             "type": "CLOSE_WRITE",
         })
 
@@ -952,6 +993,7 @@ class PGBaseBackup(Thread):
                 "end-wal-segment": backup_end_wal_segment,
                 "pg-version": self.pg_version_server,
                 "active-backup-mode": self.site_config["active_backup_mode"],
+                "basebackup-mode": self.site_config["basebackup_mode"],
                 "start-time": backup_start_time,
                 "start-wal-segment": backup_start_wal_segment,
                 "total-size-plain": total_size_plain,

--- a/pghoard/common.py
+++ b/pghoard/common.py
@@ -34,12 +34,15 @@ class StrEnum(str, enum.Enum):
 class BaseBackupFormat(StrEnum):
     v1 = "pghoard-bb-v1"
     v2 = "pghoard-bb-v2"
+    standalone = "pghoard-bb-standalone"
+    standalone_bb_xlogs = "pghoard-bb-standalone-xlogs"
     delta_v1 = "pghoard-delta-v1"
 
 
 @enum.unique
 class BaseBackupMode(StrEnum):
     basic = "basic"
+    basic_gzip = "basic-gzip"
     delta = "delta"
     local_tar = "local-tar"
     local_tar_delta_stats = "local-tar-delta-stats"

--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -53,6 +53,14 @@ class CompressorThread(Thread):
             rest, _ = os.path.split(original_path)
             rest, backupname = os.path.split(rest)
             object_path = os.path.join("basebackup", backupname)
+        elif filetype == "basebackup_xlogs":
+            rest, _ = os.path.split(original_path)
+            rest, backupname = os.path.split(rest)
+
+            # the pg_wal.tar[.gz] / pg_xlog.tar[.gz] gets written to the basebackup directory
+            # so we need to temporarily append a different extension to the wals
+            # file so we can properly upload it to storage later on
+            object_path = os.path.join("basebackup", backupname + ".wals")
         else:
             object_path = os.path.join("xlog", os.path.basename(original_path))
 
@@ -126,9 +134,12 @@ class CompressorThread(Thread):
         close_write = event["type"] == "CLOSE_WRITE"
         move = event["type"] == "MOVE" and event["src_path"].endswith(".partial")
 
-        if close_write and os.path.basename(event["full_path"]) == "base.tar":
+        basename = os.path.basename(event["full_path"])
+        if close_write and basename in {"base.tar", "base.tar.gz"}:
             return "basebackup"
-        elif (move or close_write) and wal.TIMELINE_RE.match(os.path.basename(event["full_path"])):
+        elif (move or close_write) and wal.TIMELINE_RE.match(basename):
+            return "timeline"
+        elif (move or close_write) and wal.TIMELINE_RE.match(basename):
             return "timeline"
         # for xlog we get both move and close_write on pg10+ (in that order: the write is from an fsync by name)
         # -> for now we pick MOVE because that's compatible with pg9.x, but this leaves us open to a problem with
@@ -136,8 +147,10 @@ class CompressorThread(Thread):
         #    not find the file anymore. This ends up in a hickup in pg_receivewal.
         # TODO: when we drop pg9.x support, switch to close_write here and in all other places where we generate an xlog/WAL
         #       compression event: https://github.com/aiven/pghoard/commit/29d2ee76139e8231b40619beea0703237eb6b9cc
-        elif move and wal.WAL_RE.match(os.path.basename(event["full_path"])):
+        elif move and wal.WAL_RE.match(basename):
             return "xlog"
+        elif close_write and basename in {"pg_wal.tar", "pg_xlog.tar", "pg_wal.tar.gz", "pg_xlog.tar.gz"}:
+            return "basebackup_xlogs"
 
         return None
 
@@ -268,6 +281,11 @@ class CompressorThread(Thread):
         if site not in self.state:
             self.state[site] = {
                 "basebackup": {
+                    "original_data": 0,
+                    "compressed_data": 0,
+                    "count": 0
+                },
+                "basebackup_xlogs": {
                     "original_data": 0,
                     "compressed_data": 0,
                     "count": 0

--- a/pghoard/gnutaremu.py
+++ b/pghoard/gnutaremu.py
@@ -13,6 +13,7 @@ class GnuTarEmulator:
     are supported."""
     def __init__(self):
         parser = argparse.ArgumentParser()
+        parser.add_argument("-z", "--gunzip", help="Filter the archive through gzip", action="store_true", required=True)
         parser.add_argument("-x", "--extract", help="Extract a file", action="store_true", required=True)
         parser.add_argument("-f", "--file", help="Specify the file to extract, - for stdin", type=str, required=True)
         parser.add_argument("-C", "--directory", help="Target directory for extraction", type=str)
@@ -40,7 +41,7 @@ class GnuTarEmulator:
 
     def _extract(self, file):
         paths = []
-        with tarfile.open(fileobj=file, mode="r|") as tar:
+        with tarfile.open(fileobj=file, mode="r|" if not self.args.gunzip else "r|gz") as tar:
             for tarinfo in tar:
                 target_name = self._build_target_name(tarinfo.name)
                 if not target_name:

--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -31,7 +31,7 @@ from typing import Dict, List, Optional
 from psycopg2.extensions import adapt
 from requests import Session
 
-from pghoard.common import BaseBackupFormat, StrEnum
+from pghoard.common import BaseBackupFormat, BaseBackupMode, StrEnum
 from pghoard.rohmu import compat, dates, get_transfer, rohmufile
 from pghoard.rohmu.errors import (Error, InvalidConfigurationError, MaybeRecoverableError)
 
@@ -119,6 +119,7 @@ def create_recovery_conf(
         "--xlog",
         "%f",
     ]
+
     with open(os.path.join(dirpath, "PG_VERSION"), "r") as fp:
         pg_version = LooseVersion(fp.read().strip())
 
@@ -527,6 +528,26 @@ class Restore:
             tablespaces, basebackup_data_files, empty_dirs = self._get_delta_basebackup_data(
                 site, metadata, basebackup["name"]
             )
+        elif metadata.get("format") == BaseBackupFormat.standalone:
+            basebackup_data_files = [FilePathInfo(name=basebackup["name"], size=basebackup["size"])]
+
+            # have a base.tar and pg_wal.tar[.gz] or pg_xlog.tar[.gz] file for the wal files
+            xlogs_bb_metadata = self.storage.get_basebackup_metadata(
+                basebackup["name"].replace("/basebackup/", "/basebackup_xlogs/")
+            )
+
+            basebackup_data_files.append(
+                FilePathInfo(
+                    metadata=xlogs_bb_metadata,
+                    name=os.path.join(self._get_site_prefix(site), "basebackup_xlogs", os.path.basename(basebackup["name"])),
+                    size=int(xlogs_bb_metadata["original-file-size"])
+                )
+            )
+
+            pg_version = xlogs_bb_metadata["pg-version"]
+            # the basebackup_xlogs might be encountered before the main basebackup so have to pre-emptively create
+            # the pg_wal / pg_xlog directory
+            dirs_to_create.append(pgdata + "/" + "pg_wal" if pg_version >= "10" else "pg_xlog")
         else:
             # Object is a raw (encrypted, compressed) basebackup
             basebackup_data_files = [FilePathInfo(name=basebackup["name"], size=basebackup["size"])]
@@ -905,10 +926,16 @@ class ChunkFetcher:
 
     def _build_tar_args(self, metadata):
         base_args = [self.config["tar_executable"], "-xf", "-", "-C", self.pgdata]
+        basebackup_mode = metadata.get("basebackup-mode")
+        if basebackup_mode == BaseBackupMode.basic_gzip:
+            base_args[1] = "-zxf"
+
         file_format = metadata.get("format")
         if not file_format:
             return base_args
-        elif file_format in {BaseBackupFormat.v1, BaseBackupFormat.v2, BaseBackupFormat.delta_v1}:
+        elif file_format in {
+            BaseBackupFormat.standalone, BaseBackupFormat.v1, BaseBackupFormat.v2, BaseBackupFormat.delta_v1
+        }:
             extra_args = ["--exclude", ".pghoard_tar_metadata.json", "--transform", "s,^pgdata/,,"]
             if file_format == BaseBackupFormat.delta_v1:
                 extra_args += ["--exclude", ".manifest.json"]
@@ -921,7 +948,15 @@ class ChunkFetcher:
                         tsname.replace("\\", "\\\\").replace(",", "\\,"), settings["path"].replace(",", "\\,")
                     )
                 )
+
             return base_args + extra_args
+        elif file_format == BaseBackupFormat.standalone_bb_xlogs:
+            pg_version = metadata.get("pg-version")
+
+            # extract the wal files to the pg_wal / pg_xlog directory
+            base_args[-1] = base_args[-1] + "/" + "pg_wal" if pg_version >= "10" else "pg_xlog"
+
+            return base_args
         else:
             raise RestoreError("Unrecognized basebackup format {!r}".format(file_format))
 

--- a/pghoard/transfer.py
+++ b/pghoard/transfer.py
@@ -37,31 +37,18 @@ class TransferAgent(Thread):
         self.log.debug("TransferAgent initialized")
 
     def set_state_defaults_for_site(self, site):
+        EMPTY = {"data": 0, "count": 0, "time_taken": 0.0, "failures": 0, "xlogs_since_basebackup": 0, "last_success": None}
+
         if site not in self.state:
-            EMPTY = {
-                "data": 0,
-                "count": 0,
-                "time_taken": 0.0,
-                "failures": 0,
-                "xlogs_since_basebackup": 0,
-                "last_success": None
-            }
+            self.state[site] = {}
 
-            def defaults():
-                return {
-                    "basebackup": EMPTY.copy(),
-                    "basebackup_chunk": EMPTY.copy(),
-                    "basebackup_delta": EMPTY.copy(),
-                    "timeline": EMPTY.copy(),
-                    "xlog": EMPTY.copy(),
-                }
+        for dtype in ["upload", "download", "metadata", "list"]:
+            if dtype not in self.state[site]:
+                self.state[site][dtype] = {}
 
-            self.state[site] = {
-                "upload": defaults(),
-                "download": defaults(),
-                "metadata": defaults(),
-                "list": defaults(),
-            }
+            for bbdir in ["basebackup", "basebackup_chunk", "basebackup_delta", "basebackup_xlogs", "timeline", "xlog"]:
+                if bbdir not in self.state[site][dtype]:
+                    self.state[site][dtype][bbdir] = EMPTY.copy()
 
     def get_object_storage(self, site_name):
         storage = self.site_transfers.get(site_name)
@@ -79,6 +66,11 @@ class TransferAgent(Thread):
             name = os.path.join(name_parts[-2], name_parts[-1])
         elif file_to_transfer["filetype"] == "basebackup_delta":
             name = file_to_transfer["delta"]["hexdigest"]
+        elif file_to_transfer["filetype"] == "basebackup_xlogs":
+            # the compressed pg_wal.tar[.gz] / pg_xlog.tar[.gz] was given a .wals extension
+            # while being compressed and possibly encrypted, but the wals file
+            # gets uploaded to a separate directory so remove the suffix now
+            name = name_parts[-1].replace(".wals", "")
         else:
             name = name_parts[-1]
         return os.path.join(file_to_transfer["prefix"], file_to_transfer["filetype"], name)
@@ -246,7 +238,8 @@ class TransferAgent(Thread):
             else:
                 # Basebackups may be multipart uploads, depending on the driver.
                 # Swift needs to know about this so it can do possible cleanups.
-                multipart = file_to_transfer["filetype"] in {"basebackup", "basebackup_chunk", "basebackup_delta"}
+                multipart = file_to_transfer["filetype"] \
+                            in {"basebackup", "basebackup_xlogs", "basebackup_chunk", "basebackup_delta"}
                 try:
                     self.log.info("Uploading file to object store: src=%r dst=%r", file_to_transfer["local_path"], key)
                     storage.store_file_from_disk(

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -12,6 +12,7 @@ from copy import deepcopy
 from distutils.version import LooseVersion
 from queue import Queue
 from subprocess import check_call
+import json
 
 import dateutil.parser
 import psycopg2
@@ -268,8 +269,14 @@ LABEL: pg_basebackup base backup
                 assert dateutil.parser.parse(backup["metadata"]["end-time"]).tzinfo  # pylint: disable=no-member
 
             assert backups[0]["metadata"]["active-backup-mode"] == active_backup_mode
+            assert backups[0]["metadata"]["basebackup-mode"] == mode
 
-    def _test_restore_basebackup(self, db, pghoard, tmpdir, active_backup_mode="archive_command"):
+    def _test_restore_basebackup(self, db, pghoard, tmpdir, active_backup_mode="archive_command", tar_executable=None):
+        if tar_executable:
+            pghoard.config['tar_executable'] = tar_executable
+            with open(pghoard.config_path, "w") as fp:
+                json.dump(pghoard.config, fp)
+
         backup_out = tmpdir.join("test-restore").strpath
         # Restoring to empty directory works
         os.makedirs(backup_out)
@@ -345,12 +352,16 @@ LABEL: pg_basebackup base backup
         else:
             assert os.path.isfile(path) is False
 
-    def _test_basebackups(self, capsys, db, pghoard, tmpdir, mode, *, replica=False):
+    def _test_basebackups(self, capsys, db, pghoard, tmpdir, mode, *, replica=False, restore_tar_executable=None):
         self._test_create_basebackup(capsys, db, pghoard, mode, replica=replica)
-        self._test_restore_basebackup(db, pghoard, tmpdir)
+        self._test_restore_basebackup(db, pghoard, tmpdir, tar_executable=restore_tar_executable)
 
     def test_basic_standalone_hot_backups(self, capsys, db, pghoard, tmpdir):
         self._test_create_basebackup(capsys, db, pghoard, BaseBackupMode.basic, False, "standalone_hot_backup")
+        self._test_restore_basebackup(db, pghoard, tmpdir, "standalone_hot_backup")
+
+    def test_basic_gzip_standalone_hot_backups(self, capsys, db, pghoard, tmpdir):
+        self._test_create_basebackup(capsys, db, pghoard, BaseBackupMode.basic_gzip, False, "standalone_hot_backup")
         self._test_restore_basebackup(db, pghoard, tmpdir, "standalone_hot_backup")
 
     def test_pipe_standalone_hot_backups(self, capsys, db, pghoard, tmpdir):
@@ -359,6 +370,12 @@ LABEL: pg_basebackup base backup
 
     def test_basebackups_basic(self, capsys, db, pghoard, tmpdir):
         self._test_basebackups(capsys, db, pghoard, tmpdir, BaseBackupMode.basic)
+
+    def test_basebackups_basic_gzip(self, capsys, db, pghoard, tmpdir):
+        self._test_basebackups(capsys, db, pghoard, tmpdir, BaseBackupMode.basic_gzip)
+
+    def test_basebackups_basic_gzip_with_gnutaremu(self, capsys, db, pghoard, tmpdir):
+        self._test_basebackups(capsys, db, pghoard, tmpdir, BaseBackupMode.basic_gzip, restore_tar_executable="pghoard/gnutaremu.py")
 
     def test_basebackups_basic_lzma(self, capsys, db, pghoard_lzma, tmpdir):
         self._test_basebackups(capsys, db, pghoard_lzma, tmpdir, BaseBackupMode.basic)


### PR DESCRIPTION
A standalone base backup which uses -X fetch does not support using slots (either explicit or temporary), whereas -X stream does. However -X stream is not available when using pipe.

So ive enhanced the basic version of standalone hot backup to use stream, which means we collect two files a pg_[wal|xlog].tar[.gz] and base.tar.[gz].

Ive added a new derivation of basic, which is basic-gzip, which saves a lot of local disk space with a trade off which is that we compress the gzip file again.

I have some databases which have way too many WAL files to realistically replay them all in the case of a db restore, and for our use its ok to restore to the last base backup taken and replay whatever kafka events we have lost to get the db back to where it was before the failure.

So a standalone base backup makes the most sense. However the current standalone base backup does not use replication slots and in many cases it timed out and had to be discarded as the upstream db we were getting the base backup from discarded the WAL files.

This is my first version of an attempt to get an improved standalone base backup into pghoard, and ive added extra tests to show that it does indeed work as before.

I am keen to make whatever improvements might be required to get it merged.