### PR TITLE
Improved basic standalone base backup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -347,7 +347,6 @@ in the relevant site, for example::
 For more information refer to the postgresql documentation
 https://www.postgresql.org/docs/9.5/continuous-archiving.html#BACKUP-STANDALONE
 
-
 Restoring databases
 ===================
 
@@ -694,12 +693,16 @@ set.
 
 The way basebackups should be created.  The default mode, ``basic`` runs
 ``pg_basebackup`` and waits for it to write an uncompressed tar file on the
-disk before compressing and optionally encrypting it.  The alternative mode
-``pipe`` pipes the data directly from ``pg_basebackup`` to PGHoard's
-compression and encryption processing reducing the amount of temporary disk
-space that's required.
+disk before compressing and optionally encrypting it.  A ``basic-gzip`` mode
+is also available and behaves exactly the same as ``basic`` except it waits
+for ``pg_basebackup`` to write a gzip compressed tar file, which is useful
+for situations where there is insufficient disk space for an uncompressed
+backup file (especially useful for basic standalone hot backup).  The
+alternative mode ``pipe`` pipes the data directly from ``pg_basebackup`` to
+PGHoard's compression and encryption processing reducing the amount of
+temporary disk space that's required.
 
-Neither ``basic`` nor ``pipe`` modes support multiple tablespaces.
+Base backup modes ``basic``, ``basic-gzip`` and ``pipe`` do not support multiple tablespaces.
 
 Setting ``basebackup_mode`` to ``local-tar`` avoids using ``pg_basebackup``
 entirely when ``pghoard`` is running on the same host as the database.

--- a/README.rst
+++ b/README.rst
@@ -347,6 +347,11 @@ in the relevant site, for example::
 For more information refer to the postgresql documentation
 https://www.postgresql.org/docs/9.5/continuous-archiving.html#BACKUP-STANDALONE
 
+If configured with a basebackup_mode of 'pipe' standalone hot backups will not use replication slots.
+If configured with 'basic' or 'basic_gzip' basebackup_mode, then standalone hot backup will be executed with
+the -X stream option, which will use a temporary replication slot  (pghoard currently does not support
+using a physical replication slot for base backups).
+
 Restoring databases
 ===================
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -275,6 +275,12 @@ basebackup_mode (default ``"basic"``)
   ``basic``
     runs ``pg_basebackup`` and waits for it to write an uncompressed tar file on the
     disk before compressing and optionally encrypting it.
+
+  ``basic-gzip``
+    runs ``pg_basebackup`` and waits for it to write an gzip compressed tar file on the
+    disk before compressing and optionally encrypting it.    This mode is especially
+    useful if doing standalone base backups and there is insufficient disk space for
+    an uncompressed base backup.
   ``pipe``
     pipes the data directly from ``pg_basebackup`` to PGHoard's
     compression and encryption processing reducing the amount of temporary disk

--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -142,8 +142,8 @@ class PGBaseBackup(Thread):
     def run(self):
         try:
             basebackup_mode = self.site_config["basebackup_mode"]
-            if basebackup_mode == BaseBackupMode.basic:
-                self.run_basic_basebackup()
+            if basebackup_mode in {BaseBackupMode.basic, BaseBackupMode.basic_gzip}:
+                self.run_basic_basebackup(basebackup_mode)
             elif basebackup_mode == BaseBackupMode.local_tar:
                 self.run_local_tar_basebackup()
             elif basebackup_mode == BaseBackupMode.delta:
@@ -185,7 +185,7 @@ class PGBaseBackup(Thread):
                     return raw_basebackup, compressed_basebackup
             i += 1
 
-    def get_command_line(self, output_name):
+    def get_command_line(self, output_name, basebackup_mode):
         command = [
             self.site_config["pg_basebackup_path"],
             "--format",
@@ -196,6 +196,9 @@ class PGBaseBackup(Thread):
             "--pgdata",
             output_name,
         ]
+
+        if basebackup_mode == BaseBackupMode.basic_gzip:
+            command.extend(["--gzip"])
 
         if self.site_config["active_backup_mode"] == "standalone_hot_backup":
             if self.pg_version_server >= 100000:
@@ -223,6 +226,7 @@ class PGBaseBackup(Thread):
         if output_file:
             with suppress(FileNotFoundError):
                 os.unlink(output_file)
+
         raise BackupFailure(msg)
 
     def basebackup_compression_pipe(self, proc, basebackup_path):
@@ -294,7 +298,7 @@ class PGBaseBackup(Thread):
         start_wal_segment = wal.get_current_wal_from_identify_system(connection_string)
 
         temp_basebackup_dir, compressed_basebackup = self.get_paths_for_backup(self.basebackup_path)
-        command = self.get_command_line("-")
+        command = self.get_command_line("-", BaseBackupMode.pipe)
         self.log.debug("Starting to run: %r", command)
         proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         setattr(proc, "basebackup_start_time", time.monotonic())
@@ -337,6 +341,7 @@ class PGBaseBackup(Thread):
             "original-file-size": original_input_size,
             "pg-version": self.pg_version_server,
             "active-backup-mode": self.site_config["active_backup_mode"],
+            "basebackup-mode": self.site_config["basebackup_mode"],
         })
         metadata.update(self.metadata)
 
@@ -364,14 +369,16 @@ class PGBaseBackup(Thread):
         return start_wal_segment, start_time
 
     def parse_backup_label_in_tar(self, basebackup_path):
-        with tarfile.TarFile(name=basebackup_path, mode="r") as tar:
+        with tarfile.open(name=basebackup_path, mode="r:gz" if "tar.gz" in basebackup_path else "r") as tar:
             content = tar.extractfile("backup_label").read()  # pylint: disable=no-member
         return self.parse_backup_label(content)
 
-    def run_basic_basebackup(self):
+    def run_basic_basebackup(self, basebackup_mode):
         basebackup_directory, _ = self.get_paths_for_backup(self.basebackup_path)
-        basebackup_tar_file = os.path.join(basebackup_directory, "base.tar")
-        command = self.get_command_line(basebackup_directory)
+        basebackup_file_extension = "tar.gz" if basebackup_mode == BaseBackupMode.basic_gzip else "tar"
+        basebackup_tar_filename = "base." + basebackup_file_extension
+        basebackup_tar_file = os.path.join(basebackup_directory, basebackup_tar_filename)
+        command = self.get_command_line(basebackup_directory, basebackup_mode)
 
         self.log.debug("Starting to run: %r", command)
         proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -390,18 +397,23 @@ class PGBaseBackup(Thread):
                     self.latest_activity = datetime.datetime.utcnow()
             if proc.poll() is not None:
                 break
+
         self.check_command_success(proc, basebackup_tar_file)
 
         start_wal_segment, start_time = self.parse_backup_label_in_tar(basebackup_tar_file)
+        metadata = {
+            **self.metadata,
+            "start-time": start_time,
+            "start-wal-segment": start_wal_segment,
+            "pg-version": self.pg_version_server,
+            "active-backup-mode": self.site_config["active_backup_mode"],
+            "basebackup-mode": self.site_config["basebackup_mode"],
+        }
+
         self.compression_queue.put({
             "callback_queue": self.callback_queue,
             "full_path": basebackup_tar_file,
-            "metadata": {
-                **self.metadata,
-                "start-time": start_time,
-                "start-wal-segment": start_wal_segment,
-                "active-backup-mode": self.site_config["active_backup_mode"],
-            },
+            "metadata": metadata,
             "type": "CLOSE_WRITE",
         })
 
@@ -952,6 +964,7 @@ class PGBaseBackup(Thread):
                 "end-wal-segment": backup_end_wal_segment,
                 "pg-version": self.pg_version_server,
                 "active-backup-mode": self.site_config["active_backup_mode"],
+                "basebackup-mode": self.site_config["basebackup_mode"],
                 "start-time": backup_start_time,
                 "start-wal-segment": backup_start_wal_segment,
                 "total-size-plain": total_size_plain,

--- a/pghoard/common.py
+++ b/pghoard/common.py
@@ -40,6 +40,7 @@ class BaseBackupFormat(StrEnum):
 @enum.unique
 class BaseBackupMode(StrEnum):
     basic = "basic"
+    basic_gzip = "basic-gzip"
     delta = "delta"
     local_tar = "local-tar"
     local_tar_delta_stats = "local-tar-delta-stats"

--- a/pghoard/common.py
+++ b/pghoard/common.py
@@ -34,6 +34,8 @@ class StrEnum(str, enum.Enum):
 class BaseBackupFormat(StrEnum):
     v1 = "pghoard-bb-v1"
     v2 = "pghoard-bb-v2"
+    standalone = "pghoard-bb-standalone"
+    standalone_bb_xlogs = "pghoard-bb-standalone-xlogs"
     delta_v1 = "pghoard-delta-v1"
 
 

--- a/pghoard/gnutaremu.py
+++ b/pghoard/gnutaremu.py
@@ -13,6 +13,7 @@ class GnuTarEmulator:
     are supported."""
     def __init__(self):
         parser = argparse.ArgumentParser()
+        parser.add_argument("-z", "--gunzip", help="Filter the archive through gzip", action="store_true", required=False)
         parser.add_argument("-x", "--extract", help="Extract a file", action="store_true", required=True)
         parser.add_argument("-f", "--file", help="Specify the file to extract, - for stdin", type=str, required=True)
         parser.add_argument("-C", "--directory", help="Target directory for extraction", type=str)
@@ -40,7 +41,9 @@ class GnuTarEmulator:
 
     def _extract(self, file):
         paths = []
-        with tarfile.open(fileobj=file, mode="r|") as tar:
+        # r|gz fails on smaller files, so the tests fail, ive verified this works with really big .tar.gz
+        # files from s3
+        with tarfile.open(fileobj=file, mode="r|" if not self.args.gunzip else "r:gz") as tar:
             for tarinfo in tar:
                 target_name = self._build_target_name(tarinfo.name)
                 if not target_name:

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -355,6 +355,8 @@ class PGHoard:
                     )
         elif metadata.get("format") == BaseBackupFormat.delta_v1:
             basebackup_data_files.extend(self._get_delta_basebackup_files(site, storage, metadata, basebackup, basebackups))
+        elif metadata.get("format") == BaseBackupFormat.standalone:
+            basebackup_data_files.extend([os.path.join(self._get_site_prefix(site), "basebackup_xlogs", basebackup)])
 
         self.log.debug("Deleting basebackup datafiles: %r", ", ".join(basebackup_data_files))
         for obj_key in basebackup_data_files:

--- a/pghoard/transfer.py
+++ b/pghoard/transfer.py
@@ -37,31 +37,18 @@ class TransferAgent(Thread):
         self.log.debug("TransferAgent initialized")
 
     def set_state_defaults_for_site(self, site):
+        EMPTY = {"data": 0, "count": 0, "time_taken": 0.0, "failures": 0, "xlogs_since_basebackup": 0, "last_success": None}
+
         if site not in self.state:
-            EMPTY = {
-                "data": 0,
-                "count": 0,
-                "time_taken": 0.0,
-                "failures": 0,
-                "xlogs_since_basebackup": 0,
-                "last_success": None
-            }
+            self.state[site] = {}
 
-            def defaults():
-                return {
-                    "basebackup": EMPTY.copy(),
-                    "basebackup_chunk": EMPTY.copy(),
-                    "basebackup_delta": EMPTY.copy(),
-                    "timeline": EMPTY.copy(),
-                    "xlog": EMPTY.copy(),
-                }
+        for dtype in ["upload", "download", "metadata", "list"]:
+            if dtype not in self.state[site]:
+                self.state[site][dtype] = {}
 
-            self.state[site] = {
-                "upload": defaults(),
-                "download": defaults(),
-                "metadata": defaults(),
-                "list": defaults(),
-            }
+            for bbdir in ["basebackup", "basebackup_chunk", "basebackup_delta", "basebackup_xlogs", "timeline", "xlog"]:
+                if bbdir not in self.state[site][dtype]:
+                    self.state[site][dtype][bbdir] = EMPTY.copy()
 
     def get_object_storage(self, site_name):
         storage = self.site_transfers.get(site_name)
@@ -79,6 +66,11 @@ class TransferAgent(Thread):
             name = os.path.join(name_parts[-2], name_parts[-1])
         elif file_to_transfer["filetype"] == "basebackup_delta":
             name = file_to_transfer["delta"]["hexdigest"]
+        elif file_to_transfer["filetype"] == "basebackup_xlogs":
+            # the compressed pg_wal.tar[.gz] / pg_xlog.tar[.gz] was given a .wals extension
+            # while being compressed and possibly encrypted, but the wals file
+            # gets uploaded to a separate directory so remove the suffix now
+            name = name_parts[-1].replace(".wals", "")
         else:
             name = name_parts[-1]
         return os.path.join(file_to_transfer["prefix"], file_to_transfer["filetype"], name)
@@ -246,7 +238,8 @@ class TransferAgent(Thread):
             else:
                 # Basebackups may be multipart uploads, depending on the driver.
                 # Swift needs to know about this so it can do possible cleanups.
-                multipart = file_to_transfer["filetype"] in {"basebackup", "basebackup_chunk", "basebackup_delta"}
+                multipart = file_to_transfer["filetype"] \
+                            in {"basebackup", "basebackup_xlogs", "basebackup_chunk", "basebackup_delta"}
                 try:
                     self.log.info("Uploading file to object store: src=%r dst=%r", file_to_transfer["local_path"], key)
                     storage.store_file_from_disk(


### PR DESCRIPTION
A standalone base backup which uses -X fetch does not support using slots (either explicit or temporary), whereas -X stream does. However -X stream is not available when using pipe.

So ive enhanced the basic version of standalone hot backup to use stream, which means we collect two files a pg_[wal|xlog].tar[.gz] and base.tar.[gz].

Ive added a new derivation of basic, which is basic-gzip, which saves a lot of local disk space with a trade off which is that we compress the gzip file again.

I have some databases which have way too many WAL files to realistically replay them all in the case of a db restore, and for our use its ok to restore to the last base backup taken and replay whatever kafka events we have lost to get the db back to where it was before the failure.

So a standalone base backup makes the most sense. However the current standalone base backup does not use replication slots and in many cases it timed out and had to be discarded as the upstream db we were getting the base backup from discarded the WAL files.

This is my first version of an attempt to get an improved standalone base backup into pghoard, and ive added extra tests to show that it does indeed work as before.

I am keen to make whatever improvements might be required to get it merged.

I closed a previous PR, because I encountered a restore issue in production (a canary installation), which has now been resolved