### PR TITLE
Change standalone basebackups

### DIFF
--- a/pghoard/wal.py
+++ b/pghoard/wal.py
@@ -116,9 +116,7 @@ class LSN:
 
     def _assert_sane_for_comparison(self, other):
         if not isinstance(other, LSN):
-            raise ValueError(f"Cannot compare LSN to {type(other)}")
-        if self.timeline_id != other.timeline_id:
-            raise ValueError("Cannot compare LSN on different timelines")
+            raise ValueError(f"Cannot compare LSN to {type(other)} ({self} {other}")
         if self.server_version != other.server_version:
             raise ValueError("Cannot compare LSN on different server versions")
 
@@ -131,7 +129,7 @@ class LSN:
         self._assert_sane_for_comparison(other)
         return self.lsn < other.lsn
 
-    def __lte__(self, other) -> bool:
+    def __le__(self, other) -> bool:
         self._assert_sane_for_comparison(other)
         return self.lsn <= other.lsn
 
@@ -139,7 +137,7 @@ class LSN:
         self._assert_sane_for_comparison(other)
         return self.lsn > other.lsn
 
-    def __gte__(self, other) -> bool:
+    def __ge__(self, other) -> bool:
         self._assert_sane_for_comparison(other)
         return self.lsn >= other.lsn
 

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -269,7 +269,7 @@ LABEL: pg_basebackup base backup
 
             assert backups[0]["metadata"]["active-backup-mode"] == active_backup_mode
 
-    def _test_restore_basebackup(self, db, pghoard, tmpdir, active_backup_mode="archive_command"):
+    def _test_restore_basebackup(self, db, pghoard, tmpdir):
         backup_out = tmpdir.join("test-restore").strpath
         # Restoring to empty directory works
         os.makedirs(backup_out)
@@ -340,10 +340,9 @@ LABEL: pg_basebackup base backup
             wal_dir = "pg_wal"
 
         path = os.path.join(backup_out, wal_dir, backups[0]["metadata"]["start-wal-segment"])
-        if active_backup_mode == "standalone_hot_backup":
-            assert os.path.isfile(path) is True
-        else:
-            assert os.path.isfile(path) is False
+        # Basebackups don't include any wal file. If necessary, they are
+        # fetched by a separate walreceiver process.
+        assert os.path.isfile(path) is False
 
     def _test_basebackups(self, capsys, db, pghoard, tmpdir, mode, *, replica=False):
         self._test_create_basebackup(capsys, db, pghoard, mode, replica=replica)
@@ -351,11 +350,11 @@ LABEL: pg_basebackup base backup
 
     def test_basic_standalone_hot_backups(self, capsys, db, pghoard, tmpdir):
         self._test_create_basebackup(capsys, db, pghoard, BaseBackupMode.basic, False, "standalone_hot_backup")
-        self._test_restore_basebackup(db, pghoard, tmpdir, "standalone_hot_backup")
+        self._test_restore_basebackup(db, pghoard, tmpdir)
 
     def test_pipe_standalone_hot_backups(self, capsys, db, pghoard, tmpdir):
         self._test_create_basebackup(capsys, db, pghoard, BaseBackupMode.pipe, False, "standalone_hot_backup")
-        self._test_restore_basebackup(db, pghoard, tmpdir, "standalone_hot_backup")
+        self._test_restore_basebackup(db, pghoard, tmpdir)
 
     def test_basebackups_basic(self, capsys, db, pghoard, tmpdir):
         self._test_basebackups(capsys, db, pghoard, tmpdir, BaseBackupMode.basic)


### PR DESCRIPTION
In order to avoid the problems listed in #467, I propose this PR to change the standalone basebackups behaviour.

Instead of embedding all the required wals in the basebackup, this PR starts a walreceiver for the duration of the backup.
This should resolve the problem of retrieving the WAL files using the fetch method, documented in the above-mentioned PR, without introducing the need for a new backup format.