### PR TITLE
Allow to set null as a compression algorithm

### DIFF
--- a/pghoard/rohmu/filewrap.py
+++ b/pghoard/rohmu/filewrap.py
@@ -85,6 +85,21 @@ class FileWrap(io.BufferedIOBase):
         raise io.UnsupportedOperation("Write not supported")
 
 
+class NoopFileWrap(FileWrap):
+    def write(self, data):
+        self._check_not_closed()
+        self.next_fp.write(data)
+        self.offset += len(data)
+        return len(data)
+
+    def read(self, size=-1):
+        self._check_not_closed()
+        out = self.next_fp.read(size)
+        if out:
+            self.offset += len(out)
+        return out
+
+
 class Sink:
     """Sink performs transformation for received input data and passes it forward to
     given target sink. Data is fed to this class via it's `write` method and that in

--- a/pghoard/rohmu/rohmufile.py
+++ b/pghoard/rohmu/rohmufile.py
@@ -12,7 +12,7 @@ from .compat import suppress
 from .compressor import CompressionFile, DecompressionFile, DecompressSink
 from .encryptor import DecryptorFile, DecryptSink, EncryptorFile
 from .errors import InvalidConfigurationError
-from .filewrap import ThrottleSink
+from .filewrap import NoopFileWrap, ThrottleSink
 
 
 def _fileobj_name(input_obj):
@@ -99,10 +99,10 @@ def read_file(*, input_obj, output_obj, metadata, key_lookup, progress_callback=
 def file_writer(*, fileobj, compression_algorithm=None, compression_level=0, compression_threads=0, rsa_public_key=None):
     if rsa_public_key:
         fileobj = EncryptorFile(fileobj, rsa_public_key)
-
     if compression_algorithm:
         fileobj = CompressionFile(fileobj, compression_algorithm, compression_level, compression_threads)
-
+    else:
+        fileobj = NoopFileWrap(fileobj)
     return fileobj
 
 


### PR DESCRIPTION
While debugging pghoard, I noticed that it could be nice to disable compression altogether.
Looking at the code, I thought it ought to support it already, but that wasn't the case as we needed a FileWrap to make sure the underlying, real, fd is not closed too early.

I haven't been able to dig into why we need to keep the last fd from the stack open though...