### PR TITLE
Refactor queue events.

### DIFF
--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -4,23 +4,81 @@ pghoard - compressor threads
 Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
+import enum
 import hashlib
 import logging
 import math
 import os
 import socket
 import time
+from collections import defaultdict
+from dataclasses import dataclass
 from io import BytesIO
+from pathlib import Path
 from queue import Empty, Queue
 from tempfile import NamedTemporaryFile
 from threading import Event, Thread
-from typing import Dict, Optional, Set
+from typing import BinaryIO, Dict, Optional, Set, Union
 
 from pghoard import config as pgh_config
 from pghoard import wal
-from pghoard.common import write_json_file
+from pghoard.common import (CallbackEvent, CallbackQueue, FileType, FileTypePrefixes, QuitEvent, StrEnum, write_json_file)
 from pghoard.metrics import Metrics
-from pghoard.rohmu import errors, rohmufile
+from pghoard.rohmu import rohmufile
+from pghoard.transfer import TransferQueue, UploadEvent
+
+
+@enum.unique
+class CompressionOperation(StrEnum):
+    Decompress = "DECOMPRESS"
+    Compress = "COMPRESS"
+
+
+@dataclass(frozen=True)
+class BaseCompressorEvent:
+    file_type: FileType
+    file_path: Path
+    backup_site_key: str
+    source_data: Union[BinaryIO, Path]
+    callback_queue: CallbackQueue
+    metadata: Dict[str, str]
+
+
+@dataclass(frozen=True)
+class CompressionEvent(BaseCompressorEvent):
+    delete_file_after_compression: bool = False
+    compress_to_memory: bool = False
+
+    @property
+    def operation(self):
+        return CompressionOperation.Compress
+
+
+@dataclass(frozen=True)
+class DecompressionEvent(BaseCompressorEvent):
+
+    destination_path: Path
+
+    @property
+    def operation(self):
+        return CompressionOperation.Decompress
+
+
+# Should be changed to Queue[Union[CompressionEvent, Literal[QuitEvent]] once
+# we drop older python versions
+CompressionQueue = Queue
+
+
+@dataclass(frozen=True)
+class WalFileDeletionEvent:
+    backup_site_key: str
+    file_path: Path
+    file_type: Optional[FileType] = None
+
+
+# Should be changed to Queue[WalFileDeletionEvent] once
+# we drop older python versions
+WalFileDeletionQueue = Queue
 
 
 class CompressorThread(Thread):
@@ -30,8 +88,8 @@ class CompressorThread(Thread):
     def __init__(
         self,
         config_dict: Dict,
-        compression_queue: Queue,
-        transfer_queue: Queue,
+        compression_queue: CompressionQueue,
+        transfer_queue: TransferQueue,
         metrics: Metrics,
         critical_failure_event: Event,
         wal_file_deletion_queue: Queue,
@@ -48,33 +106,19 @@ class CompressorThread(Thread):
         self.critical_failure_event = critical_failure_event
         self.log.debug("Compressor initialized")
 
-    def get_compressed_file_path(self, site, filetype, original_path):
-        if filetype == "basebackup":
-            rest, _ = os.path.split(original_path)
-            rest, backupname = os.path.split(rest)
-            object_path = os.path.join("basebackup", backupname)
-        else:
-            object_path = os.path.join("xlog", os.path.basename(original_path))
-
-        cfp = os.path.join(self.config["backup_location"], self.config["backup_sites"][site]["prefix"], object_path)
-        self.log.debug("compressed_file_path for %r is %r", original_path, cfp)
-        return cfp
-
-    def find_site_for_file(self, filepath):
-        # Formats like:
-        # /home/foo/t/default/xlog/000000010000000000000014
-        # /home/foo/t/default/basebackup/2015-02-06_3/base.tar
-        for site in self.config["backup_sites"]:
-            site_path = os.path.join(self.config["backup_location"], self.config["backup_sites"][site]["prefix"])
-            if filepath.startswith(site_path):
-                return site
-        raise errors.InvalidConfigurationError("Could not find backup site for {}".format(filepath))
+    def get_compressed_file_dir(self, site):
+        # FIXME: this is shared with pghoard.py and convoluted
+        prefix = Path(self.config["backup_sites"][site]["prefix"])
+        path = Path(self.config["backup_location"]) / prefix
+        if not path.exists():
+            path.mkdir()
+        return path
 
     def compression_algorithm(self):
         return self.config["compression"]["algorithm"]
 
     def run(self):
-        event: Optional[Dict] = None
+        event: Optional[CompressionEvent] = None
         while self.running:
             if event is None:
                 attempt = 1
@@ -83,33 +127,29 @@ class CompressorThread(Thread):
                 except Empty:
                     continue
             try:
-                if event["type"] == "QUIT":
+                if event is QuitEvent:
                     break
-                if event["type"] == "DECOMPRESSION":
+                if event.operation == CompressionOperation.Decompress:
                     self.handle_decompression_event(event)
-                else:
-                    filetype = self.get_event_filetype(event)
-                    if filetype:
-                        self.handle_event(event, filetype)
-                    elif "callback_queue" in event and event["callback_queue"]:
+                elif event.operation == CompressionOperation.Compress:
+                    file_type = event.file_type
+                    if file_type:
+                        self.handle_event(event)
+                    elif event.callback_queue:
                         self.log.debug("Returning success for unrecognized and ignored event: %r", event)
-                        event["callback_queue"].put({"success": True, "opaque": event.get("opaque")})
+                        event.callback_queue.put(CallbackEvent(success=True))
                 event = None
             except Exception as ex:  # pylint: disable=broad-except
-                if "blob" in event:
-                    log_event = dict(event, blob="<{} bytes>".format(len(event["blob"])))
-                else:
-                    log_event = event
                 attempt_message = ""
                 if attempt < self.MAX_FAILED_RETRY_ATTEMPTS:
                     attempt_message = f" (attempt {attempt} of {self.MAX_FAILED_RETRY_ATTEMPTS})"
 
-                self.log.exception("Problem handling%s: %r: %s: %s", attempt_message, log_event, ex.__class__.__name__, ex)
+                self.log.exception("Problem handling%s: %r: %s: %s", attempt_message, event, ex.__class__.__name__, ex)
                 self.metrics.unexpected_exception(ex, where="compressor_run")
                 if attempt >= self.MAX_FAILED_RETRY_ATTEMPTS:
                     # When this happens, execution must be stopped in order to prevent data corruption
-                    if "callback_queue" in event and event["callback_queue"]:
-                        event["callback_queue"].put({"success": False, "exception": ex, "opaque": event.get("opaque")})
+                    if event.callback_queue:
+                        event.callback_queue.put(CallbackEvent(success=False, exception=ex))
                     self.running = False
                     self.metrics.unexpected_exception(ex, where="compressor_run_critical")
                     self.critical_failure_event.set()
@@ -122,69 +162,52 @@ class CompressorThread(Thread):
 
         self.log.debug("Quitting Compressor")
 
-    def get_event_filetype(self, event):
-        close_write = event["type"] == "CLOSE_WRITE"
-        move = event["type"] == "MOVE" and event["src_path"].endswith(".partial")
-
-        if close_write and os.path.basename(event["full_path"]) == "base.tar":
-            return "basebackup"
-        elif (move or close_write) and wal.TIMELINE_RE.match(os.path.basename(event["full_path"])):
-            return "timeline"
-        # for xlog we get both move and close_write on pg10+ (in that order: the write is from an fsync by name)
-        # -> for now we pick MOVE because that's compatible with pg9.x, but this leaves us open to a problem with
-        #    in case the compressor is so fast to compress and then unlink the file that the fsync by name does
-        #    not find the file anymore. This ends up in a hickup in pg_receivewal.
-        # TODO: when we drop pg9.x support, switch to close_write here and in all other places where we generate an xlog/WAL
-        #       compression event: https://github.com/aiven/pghoard/commit/29d2ee76139e8231b40619beea0703237eb6b9cc
-        elif move and wal.WAL_RE.match(os.path.basename(event["full_path"])):
-            return "xlog"
-
-        return None
-
     def handle_decompression_event(self, event):
-        with open(event["local_path"], "wb") as output_obj:
+        with open(event.destination_path, "wb") as output_obj:
             rohmufile.read_file(
-                input_obj=BytesIO(event["blob"]),
+                input_obj=event.source_data,
                 output_obj=output_obj,
-                metadata=event.get("metadata"),
-                key_lookup=pgh_config.key_lookup_for_site(self.config, event["site"]),
-                log_func=self.log.debug,
+                metadata=event.metadata,
+                key_lookup=pgh_config.key_lookup_for_site(self.config, event.backup_site_key),
+                log_func=self.log.debug
             )
 
-        if "callback_queue" in event:
-            event["callback_queue"].put({"success": True, "opaque": event.get("opaque")})
+        if event.callback_queue:
+            event.callback_queue.put(CallbackEvent(success=True))
 
-    def handle_event(self, event, filetype):
+    def handle_event(self, event):
         # pylint: disable=redefined-variable-type
+        file_type = event.file_type
         rsa_public_key = None
-        site = event.get("site")
-        if not site:
-            site = self.find_site_for_file(event["full_path"])
-
+        site = event.backup_site_key
         encryption_key_id = self.config["backup_sites"][site]["encryption_key_id"]
         if encryption_key_id:
             rsa_public_key = self.config["backup_sites"][site]["encryption_keys"][encryption_key_id]["public"]
-
-        compressed_blob = None
-        if event.get("compress_to_memory"):
+        remove_after_upload = False
+        if event.compress_to_memory:
             output_obj = BytesIO()
             compressed_filepath = None
+            output_data = output_obj
         else:
-            compressed_filepath = self.get_compressed_file_path(site, filetype, event["full_path"])
+            remove_after_upload = True
+            type_prefix = FileTypePrefixes[event.file_type]
+            compressed_filepath = self.get_compressed_file_dir(site) / type_prefix / event.file_path.name
+            compressed_filepath.parent.mkdir(exist_ok=True)
             output_obj = NamedTemporaryFile(
                 dir=os.path.dirname(compressed_filepath),
                 prefix=os.path.basename(compressed_filepath),
                 suffix=".tmp-compress"
             )
-
-        input_obj = event.get("input_data")
-        if not input_obj:
-            input_obj = open(event["full_path"], "rb")
+            output_data = compressed_filepath
+        if not isinstance(event.source_data, BytesIO):
+            input_obj = open(event.source_data, "rb")
+        else:
+            input_obj = event.source_data
         with output_obj, input_obj:
             hash_algorithm = self.config["hash_algorithm"]
             hasher = None
-            if filetype == "xlog":
-                wal.verify_wal(wal_name=os.path.basename(event["full_path"]), fileobj=input_obj)
+            if file_type == FileType.Wal:
+                wal.verify_wal(wal_name=event.file_path.name, fileobj=input_obj)
                 hasher = hashlib.new(hash_algorithm)
 
             original_file_size, compressed_file_size = rohmufile.write_file(
@@ -200,9 +223,9 @@ class CompressorThread(Thread):
             if compressed_filepath:
                 os.link(output_obj.name, compressed_filepath)
             else:
-                compressed_blob = output_obj.getvalue()
+                output_data = BytesIO(output_obj.getvalue())
 
-        metadata = event.get("metadata", {})
+        metadata = event.metadata
         metadata.update({
             "pg-version": self.config["backup_sites"][site].get("pg_version"),
             "compression-algorithm": self.config["compression"]["algorithm"],
@@ -215,14 +238,16 @@ class CompressorThread(Thread):
             metadata["hash-algorithm"] = hash_algorithm
         if encryption_key_id:
             metadata.update({"encryption-key-id": encryption_key_id})
+        # FIXME: why do we dump this ? Intermediate state stored on disk cannot
+        # be relied on.
         if compressed_filepath:
-            metadata_path = compressed_filepath + ".metadata"
+            metadata_path = compressed_filepath.with_name(compressed_filepath.name + ".metadata")
             write_json_file(metadata_path, metadata)
 
         self.set_state_defaults_for_site(site)
-        self.state[site][filetype]["original_data"] += original_file_size
-        self.state[site][filetype]["compressed_data"] += compressed_file_size
-        self.state[site][filetype]["count"] += 1
+        self.state[site][str(file_type)]["original_data"] += original_file_size
+        self.state[site][str(file_type)]["compressed_data"] += compressed_file_size
+        self.state[site][str(file_type)]["count"] += 1
         if original_file_size:
             size_ratio = compressed_file_size / original_file_size
             self.metrics.gauge(
@@ -231,36 +256,26 @@ class CompressorThread(Thread):
                 tags={
                     "algorithm": self.config["compression"]["algorithm"],
                     "site": site,
-                    "type": filetype,
+                    "type": file_type,
                 }
             )
-        transfer_object = {
-            "callback_queue": event.get("callback_queue"),
-            "file_size": compressed_file_size,
-            "filetype": filetype,
-            "metadata": metadata,
-            "opaque": event.get("opaque"),
-            "site": site,
-            "type": "UPLOAD",
-        }
-        if compressed_filepath:
-            transfer_object["local_path"] = compressed_filepath
-        else:
-            transfer_object["blob"] = compressed_blob
-            transfer_object["local_path"] = event["full_path"]
-
-        if event.get("delete_file_after_compression", True):
-            if filetype == "xlog":
-                delete_request = {
-                    "type": "delete_file",
-                    "site": site,
-                    "local_path": event["full_path"],
-                }
-                self.log.info("Adding to Uncompressed WAL file to deletion queue: %s", event["full_path"])
+        transfer_object = UploadEvent(
+            callback_queue=event.callback_queue,
+            file_size=compressed_file_size,
+            file_type=event.file_type,
+            metadata=metadata,
+            backup_site_key=site,
+            file_path=event.file_path,
+            source_data=output_data,
+            remove_after_upload=remove_after_upload
+        )
+        if event.delete_file_after_compression:
+            if file_type == FileType.Wal:
+                delete_request = WalFileDeletionEvent(backup_site_key=site, file_path=event.source_data)
+                self.log.info("Adding to Uncompressed WAL file to deletion queue: %s", event.source_data)
                 self.wal_file_deletion_queue.put(delete_request)
             else:
-                os.unlink(event["full_path"])
-
+                os.unlink(event.source_data)
         self.transfer_queue.put(transfer_object)
         return True
 
@@ -298,7 +313,7 @@ class WALFileDeleterThread(Thread):
     def __init__(
         self,
         config: Dict,
-        wal_file_deletion_queue: Queue,
+        wal_file_deletion_queue: WalFileDeletionQueue,
         metrics: Metrics,
     ):
         super().__init__()
@@ -307,7 +322,7 @@ class WALFileDeleterThread(Thread):
         self.metrics = metrics
         self.wal_file_deletion_queue = wal_file_deletion_queue
         self.running = True
-        self.to_be_deleted_files: Dict[str, Set[str]] = {}
+        self.to_be_deleted_files: Dict[str, Set[str]] = defaultdict(set)
         self.log.debug("WALFileDeleter initialized")
 
     def run(self):
@@ -330,16 +345,15 @@ class WALFileDeleterThread(Thread):
                 continue
 
             try:
-                if event["type"] == "QUIT":
+                if event is QuitEvent:
                     break
-                if event["type"] == "delete_file":
-                    site = event["site"]
-                    local_path = event["local_path"]
-                    if site not in self.to_be_deleted_files:
-                        self.to_be_deleted_files[site] = set()
-                    self.to_be_deleted_files[site].add(local_path)
-                else:
-                    raise RuntimeError("Received bad event")
+                site = event.backup_site_key
+                local_path = event.file_path
+                if not local_path:
+                    raise ValueError("file_path must not be None")
+                if not site:
+                    raise ValueError("backup_site_key must not be None")
+                self.to_be_deleted_files[site].add(local_path)
                 self.deleted_unneeded_files()
             except Exception as ex:  # pylint: disable=broad-except
                 self.log.exception("Problem handling event %r: %s: %s", event, ex.__class__.__name__, ex)
@@ -348,7 +362,6 @@ class WALFileDeleterThread(Thread):
                 time.sleep(0.1)
                 # If we have a problem, just keep running for now, at the worst we accumulate files
                 continue
-
         self.log.debug("Quitting WALFileDeleter")
 
     def deleted_unneeded_files(self):

--- a/pghoard/rohmu/delta/snapshot.py
+++ b/pghoard/rohmu/delta/snapshot.py
@@ -180,17 +180,17 @@ class Snapshotter:
         progress.start(3)
 
         if self.src_iterate_func:
-            src_dirs = set()
-            src_files = set()
+            src_dirs_set = set()
+            src_files_set = set()
             for item in self.src_iterate_func():
                 path = Path(item)
                 if path.is_file() and not path.is_symlink():
-                    src_files.add(path.relative_to(self.src))
+                    src_files_set.add(path.relative_to(self.src))
                 elif path.is_dir():
-                    src_dirs.add(path.relative_to(self.src))
+                    src_dirs_set.add(path.relative_to(self.src))
 
-            src_dirs = sorted(src_dirs | {p.parent for p in src_files})
-            src_files = sorted(src_files)
+            src_dirs = sorted(src_dirs_set | {p.parent for p in src_files_set})
+            src_files = sorted(src_files_set)
         else:
             src_dirs, src_files = self._list_dirs_and_files(self.src)
 

--- a/pghoard/rohmu/object_storage/swift.py
+++ b/pghoard/rohmu/object_storage/swift.py
@@ -129,14 +129,14 @@ class SwiftTransfer(BaseTransfer):
     def iter_key(self, key, *, with_metadata=True, deep=False, include_key=False):
         path = self.format_key_for_backend(key, trailing_slash=not include_key)
         self.log.debug("Listing path %r", path)
-        if deep:
+        if not deep:
             kwargs = {"delimiter": "/"}
         else:
             kwargs = {}
         _, results = self.conn.get_container(self.container_name, prefix=path, full_listing=True, **kwargs)
         for item in results:
             if "subdir" in item:
-                yield IterKeyItem(type=KEY_TYPE_PREFIX, value=self.format_key_from_backend(item["name"]).rstrip("/"))
+                yield IterKeyItem(type=KEY_TYPE_PREFIX, value=self.format_key_from_backend(item["subdir"]).rstrip("/"))
             else:
                 if with_metadata:
                     metadata = self._metadata_for_key(item["name"], resolve_manifest=True)
@@ -250,44 +250,17 @@ class SwiftTransfer(BaseTransfer):
         )
 
     def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
-        if cache_control is not None:
-            raise NotImplementedError("SwiftTransfer: cache_control support not implemented")
-
-        if multipart:
-            # Start by trying to delete the file - if it's a potential multipart file we need to manually
-            # delete it, otherwise old segments won't be cleaned up by anything.  Note that we only issue
-            # deletes with the store_file_from_disk functions, store_file_from_memory is used to upload smaller
-            # chunks.
-            with suppress(FileNotFoundFromStorageError):
-                self.delete_key(key)
-        key = self.format_key_for_backend(key)
-        headers = self._metadata_to_headers(self.sanitize_metadata(metadata))
         obsz = os.path.getsize(filepath)
         with open(filepath, "rb") as fp:
-            if obsz <= self.segment_size:
-                self.log.debug("Uploading %r to %r (%r bytes)", filepath, key, obsz)
-                self.conn.put_object(self.container_name, key, contents=fp, content_length=obsz, headers=headers)
-                return
-
-            # Segmented transfer
-            # upload segments of a file like `backup-bucket/site-name/basebackup/2016-03-22_0`
-            # to as `backup-bucket/site-name/basebackup_segments/2016-03-22_0/{:08x}`
-            segment_no = 0
-            segment_path = "{}_segments/{}/".format(os.path.dirname(key), os.path.basename(key))
-            segment_key_format = "{}{{:08x}}".format(segment_path).format
-            remaining = obsz
-            while remaining > 0:
-                this_segment_size = min(self.segment_size, remaining)
-                remaining -= this_segment_size
-                segment_no += 1
-                self.log.debug("Uploading segment %r of %r to %r (%r bytes)", segment_no, filepath, key, this_segment_size)
-                segment_key = segment_key_format(segment_no)  # pylint: disable=too-many-format-args
-                self.conn.put_object(
-                    self.container_name, segment_key, contents=fp, content_length=this_segment_size, content_type=mimetype
-                )
-            self.log.info("Uploaded %r segments of %r to %r", segment_no, key, segment_path)
-            headers["x-object-manifest"] = "{}/{}".format(self.container_name, segment_path.lstrip("/"))
-            self.conn.put_object(self.container_name, key, contents="", headers=headers, content_length=0)
+            self._store_file_contents(
+                key,
+                fp,
+                metadata=metadata,
+                multipart=multipart,
+                cache_control=cache_control,
+                mimetype=mimetype,
+                content_length=obsz
+            )
 
     def get_or_create_container(self, container_name):
         start_time = time.monotonic()
@@ -304,3 +277,75 @@ class SwiftTransfer(BaseTransfer):
                 return container_name
             raise
         return container_name
+
+    def copy_file(self, *, source_key, destination_key, metadata=None, **_kwargs):
+        source_key = self.format_key_for_backend(source_key)
+        destination_key = "/".join((self.container_name, self.format_key_for_backend(destination_key)))
+        headers = self._metadata_to_headers(self.sanitize_metadata(metadata))
+        if metadata:
+            headers["X-Fresh-Metadata"] = True
+        self.conn.copy_object(self.container_name, source_key, destination=destination_key, headers=headers)
+
+    def store_file_object(self, key, fd, *, cache_control=None, metadata=None, mimetype=None, upload_progress_fn=None):
+        metadata = metadata or {}
+        self._store_file_contents(
+            key,
+            fd,
+            cache_control=cache_control,
+            metadata=metadata,
+            mimetype=mimetype,
+            upload_progress_fn=upload_progress_fn,
+            multipart=True,
+            content_length=metadata.get("Content-Length")
+        )
+
+    def _store_file_contents(
+        self,
+        key,
+        fp,
+        cache_control=None,
+        metadata=None,
+        mimetype=None,
+        upload_progress_fn=None,
+        multipart=None,
+        content_length=None
+    ):
+        if cache_control is not None:
+            raise NotImplementedError("SwiftTransfer: cache_control support not implemented")
+
+        if multipart:
+            # Start by trying to delete the file - if it's a potential multipart file we need to manually
+            # delete it, otherwise old segments won't be cleaned up by anything.  Note that we only issue
+            # deletes with the store_file_from_disk functions, store_file_from_memory is used to upload smaller
+            # chunks.
+            with suppress(FileNotFoundFromStorageError):
+                self.delete_key(key)
+        key = self.format_key_for_backend(key)
+        headers = self._metadata_to_headers(self.sanitize_metadata(metadata))
+        # Fall back to the "one segment" if possible
+        if (not multipart) or (not content_length) or content_length <= self.segment_size:
+            self.log.debug("Uploading %r to %r (%r bytes)", fp, key, content_length)
+            self.conn.put_object(self.container_name, key, contents=fp, content_length=content_length, headers=headers)
+            return
+
+        # Segmented transfer
+        # upload segments of a file like `backup-bucket/site-name/basebackup/2016-03-22_0`
+        # to as `backup-bucket/site-name/basebackup_segments/2016-03-22_0/{:08x}`
+        segment_no = 0
+        segment_path = "{}_segments/{}/".format(os.path.dirname(key), os.path.basename(key))
+        segment_key_format = "{}{{:08x}}".format(segment_path).format
+        remaining = content_length
+        while remaining > 0:
+            this_segment_size = min(self.segment_size, remaining)
+            remaining -= this_segment_size
+            segment_no += 1
+            self.log.debug("Uploading segment %r of %r to %r (%r bytes)", segment_no, fp, key, this_segment_size)
+            segment_key = segment_key_format(segment_no)  # pylint: disable=too-many-format-args
+            self.conn.put_object(
+                self.container_name, segment_key, contents=fp, content_length=this_segment_size, content_type=mimetype
+            )
+            if upload_progress_fn:
+                upload_progress_fn(content_length - remaining)
+        self.log.info("Uploaded %r segments of %r to %r", segment_no, key, segment_path)
+        headers["x-object-manifest"] = "{}/{}".format(self.container_name, segment_path.lstrip("/"))
+        self.conn.put_object(self.container_name, key, contents="", headers=headers, content_length=0)

--- a/pghoard/transfer.py
+++ b/pghoard/transfer.py
@@ -4,29 +4,103 @@ pghoard
 Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
+import dataclasses
+import enum
 import logging
 import os
 import time
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
 from queue import Empty
 from threading import Lock, Thread
+from typing import Any, BinaryIO, Dict, Optional, Union
 
-from pghoard.common import create_alert_file, get_object_storage_config
+from pghoard.common import (
+    CallbackEvent, CallbackQueue, FileType, Queue, QuitEvent, StrEnum, create_alert_file, get_object_storage_config
+)
 from pghoard.fetcher import FileFetchManager
 from pghoard.rohmu import get_transfer
 from pghoard.rohmu.compat import suppress
-from pghoard.rohmu.errors import (FileNotFoundFromStorageError, LocalFileIsRemoteFileError)
+from pghoard.rohmu.errors import FileNotFoundFromStorageError
 
 _STATS_LOCK = Lock()
 _last_stats_transmit_time = 0
 
 
+@enum.unique
+class TransferOperation(StrEnum):
+    Download = "download"
+    Upload = "upload"
+    List = "list"
+    Metadata = "metadata"
+
+
+@dataclass(frozen=True)
+class BaseTransferEvent:
+    backup_site_key: str
+    file_type: FileType
+    file_path: Path
+    callback_queue: CallbackQueue
+
+
+@dataclass(frozen=True)
+class UploadEvent(BaseTransferEvent):
+    source_data: Union[BinaryIO, Path]
+    metadata: Dict[str, str]
+    file_size: Optional[int]
+    remove_after_upload: bool = True
+    retry_number: int = 0
+
+    @property
+    def operation(self):
+        return TransferOperation.Upload
+
+
+@dataclass(frozen=True)
+class DownloadEvent(BaseTransferEvent):
+
+    destination_path: Path
+    opaque: Optional[Any] = None
+    file_size: Optional[int] = 0
+
+    @property
+    def operation(self):
+        return TransferOperation.Download
+
+
+@dataclass(frozen=True)
+class ListEvent(BaseTransferEvent):
+    @property
+    def operation(self):
+        return TransferOperation.List
+
+
+@dataclass(frozen=True)
+class MetadataEvent(BaseTransferEvent):
+    @property
+    def operation(self):
+        return TransferOperation.Metadata
+
+
+OperationEvents = {
+    TransferOperation.Download: DownloadEvent,
+    TransferOperation.Upload: UploadEvent,
+    TransferOperation.List: ListEvent,
+    TransferOperation.Metadata: MetadataEvent
+}
+
+# Should be changed to Queue[Union[CompressionEvent, Literal[QuitEvent]] once
+# we drop older python versions
+TransferQueue = Queue
+
+
 class TransferAgent(Thread):
-    def __init__(self, config, compression_queue, mp_manager, transfer_queue, metrics, shared_state_dict):
+    def __init__(self, config, mp_manager, transfer_queue: TransferQueue, metrics, shared_state_dict):
         super().__init__()
         self.log = logging.getLogger("TransferAgent")
         self.config = config
         self.metrics = metrics
-        self.compression_queue = compression_queue
         self.mp_manager = mp_manager
         self.fetch_manager = FileFetchManager(self.config, self.mp_manager, self.get_object_storage)
         self.transfer_queue = transfer_queue
@@ -114,38 +188,40 @@ class TransferAgent(Thread):
                 file_to_transfer = self.transfer_queue.get(timeout=1.0)
             except Empty:
                 continue
-            if file_to_transfer["type"] == "QUIT":
+            if file_to_transfer is QuitEvent:
                 break
 
-            site = file_to_transfer["site"]
-            filetype = file_to_transfer["filetype"]
-            self.log.debug(
-                "Starting to %r %r, size: %r", file_to_transfer["type"], file_to_transfer["local_path"],
-                file_to_transfer.get("file_size", "unknown")
-            )
-            file_to_transfer.setdefault("prefix", self.config["backup_sites"][site]["prefix"])
+            site = file_to_transfer.backup_site_key
+            filetype = file_to_transfer.file_type
+            self.log.info("Processing TransferEvent %r", file_to_transfer)
             start_time = time.monotonic()
-            key = self.form_key_path(file_to_transfer)
-            oper = file_to_transfer["type"].lower()
-            oper_func = getattr(self, "handle_" + oper, None)
-            if oper_func is None:
-                self.log.warning("Invalid operation %r", file_to_transfer["type"])
-                continue
-
-            result = oper_func(site, key, file_to_transfer)
+            key = str(Path(file_to_transfer.backup_site_key) / file_to_transfer.file_path)
+            oper = str(file_to_transfer.operation)
+            if file_to_transfer.operation == TransferOperation.Download:
+                result = self.handle_download(site, key, file_to_transfer)
+            elif file_to_transfer.operation == TransferOperation.Upload:
+                result = self.handle_upload(site, key, file_to_transfer)
+            elif file_to_transfer.operation == TransferOperation.List:
+                result = self.handle_list(site, key, file_to_transfer)
+            elif file_to_transfer.operation == TransferOperation.Metadata:
+                result = self.handle_metadata(site, key, file_to_transfer)
+            else:
+                raise TypeError(f"Invalid transfer operation {file_to_transfer.operation}")
 
             # increment statistics counters
             self.set_state_defaults_for_site(site)
-            oper_size = file_to_transfer.get("file_size", 0)
-            if result["success"]:
-                filename = os.path.basename(file_to_transfer["local_path"])
-                if oper == "upload":
-                    if filetype == "xlog":
+            if not result:
+                self.state[site][oper][filetype]["failures"] += 1
+                continue
+            oper_size = result.payload.get("file_size", 0)
+            if result.success:
+                filename = file_to_transfer.file_path.name
+                if oper == TransferOperation.Upload:
+                    if filetype == FileType.Wal:
                         self.state[site][oper]["xlog"]["xlogs_since_basebackup"] += 1
-                    elif filetype in {"basebackup", "basebackup_delta"}:
+                    elif filetype in {FileType.Basebackup, FileType.Basebackup_chunk}:
                         # reset corresponding xlog stats at basebackup
                         self.state[site][oper]["xlog"]["xlogs_since_basebackup"] = 0
-
                     self.metrics.gauge(
                         "pghoard.xlogs_since_basebackup",
                         self.state[site][oper]["xlog"]["xlogs_since_basebackup"],
@@ -155,6 +231,7 @@ class TransferAgent(Thread):
                 self.state[site][oper][filetype]["last_success"] = time.monotonic()
                 self.state[site][oper][filetype]["count"] += 1
                 self.state[site][oper][filetype]["data"] += oper_size
+
                 self.metrics.gauge(
                     "pghoard.total_upload_size",
                     self.state[site][oper][filetype]["data"],
@@ -168,25 +245,24 @@ class TransferAgent(Thread):
             else:
                 self.state[site][oper][filetype]["failures"] += 1
 
-            if oper in {"download", "upload"}:
+            if file_to_transfer.operation in {TransferOperation.Download, TransferOperation.Upload}:
                 self.metrics.increase(
                     "pghoard.{}_size".format(oper),
                     inc_value=oper_size,
                     tags={
-                        "result": "ok" if result["success"] else "failed",
+                        "result": "ok" if result.success else "failed",
                         "type": filetype,
                         "site": site,
                     }
                 )
 
             # push result to callback_queue if provided
-            if result.get("call_callback", True) and file_to_transfer.get("callback_queue"):
-                file_to_transfer["callback_queue"].put(result)
+            if file_to_transfer.callback_queue:
+                file_to_transfer.callback_queue.put(result)
 
             self.log.info(
-                "%r %stransfer of key: %r, size: %r, origin: %r took %.3fs", file_to_transfer["type"],
-                "FAILED " if not result["success"] else "", key, oper_size,
-                file_to_transfer.get("metadata", {}).get("host"),
+                "%r %stransfer of key: %r, size: %r, took %.3fs", oper, "FAILED " if not result.success else "", key,
+                oper_size,
                 time.monotonic() - start_time
             )
 
@@ -197,93 +273,98 @@ class TransferAgent(Thread):
         try:
             storage = self.get_object_storage(site)
             items = storage.list_path(key)
-            file_to_transfer["file_size"] = len(repr(items))  # approx
-            return {"success": True, "items": items, "opaque": file_to_transfer.get("opaque")}
+            payload = {"file_size": len(repr(items)), "items": items}
+            return CallbackEvent(success=True, payload=payload)
         except FileNotFoundFromStorageError as ex:
             self.log.warning("%r not found from storage", key)
-            return {"success": False, "exception": ex, "opaque": file_to_transfer.get("opaque")}
+            return CallbackEvent(success=False, exception=ex)
         except Exception as ex:  # pylint: disable=broad-except
             self.log.exception("Problem happened when retrieving metadata: %r, %r", key, file_to_transfer)
             self.metrics.unexpected_exception(ex, where="handle_list")
-            return {"success": False, "exception": ex, "opaque": file_to_transfer.get("opaque")}
+            return CallbackEvent(success=False, exception=ex)
 
     def handle_metadata(self, site, key, file_to_transfer):
         try:
             storage = self.get_object_storage(site)
             metadata = storage.get_metadata_for_key(key)
-            file_to_transfer["file_size"] = len(repr(metadata))  # approx
-            return {"success": True, "metadata": metadata, "opaque": file_to_transfer.get("opaque")}
+            payload = {"metadata": metadata, "file_size": len(repr(metadata))}
+            return CallbackEvent(success=True, payload=payload)
         except FileNotFoundFromStorageError as ex:
             self.log.warning("%r not found from storage", key)
-            return {"success": False, "exception": ex, "opaque": file_to_transfer.get("opaque")}
+            return CallbackEvent(success=False, exception=ex)
         except Exception as ex:  # pylint: disable=broad-except
             self.log.exception("Problem happened when retrieving metadata: %r, %r", key, file_to_transfer)
             self.metrics.unexpected_exception(ex, where="handle_metadata")
-            return {"success": False, "exception": ex, "opaque": file_to_transfer.get("opaque")}
+            return CallbackEvent(success=False, exception=ex)
 
     def handle_download(self, site, key, file_to_transfer):
         try:
-            path = file_to_transfer["target_path"]
+            path = file_to_transfer.destination_path
             self.log.info("Requesting download of object key: src=%r dst=%r", key, path)
             file_size, metadata = self.fetch_manager.fetch_file(site, key, path)
-            file_to_transfer["file_size"] = file_size
-            return {"success": True, "opaque": file_to_transfer.get("opaque"), "target_path": path, "metadata": metadata}
+            payload = {"file_size": file_size, "metadata": metadata, "target_path": path}
+            return CallbackEvent(success=True, opaque=file_to_transfer.opaque, payload=payload)
         except FileNotFoundFromStorageError as ex:
             self.log.warning("%r not found from storage", key)
-            return {"success": False, "exception": ex, "opaque": file_to_transfer.get("opaque")}
+            return CallbackEvent(success=False, exception=ex, opaque=file_to_transfer.opaque)
         except Exception as ex:  # pylint: disable=broad-except
             self.log.exception("Problem happened when downloading: %r, %r", key, file_to_transfer)
             self.metrics.unexpected_exception(ex, where="handle_download")
-            return {"success": False, "exception": ex, "opaque": file_to_transfer.get("opaque")}
+            return CallbackEvent(success=False, exception=ex, opaque=file_to_transfer.opaque)
 
     def handle_upload(self, site, key, file_to_transfer):
+        payload = {"file_size": file_to_transfer.file_size}
         try:
             storage = self.get_object_storage(site)
-            unlink_local = False
-            if "blob" in file_to_transfer:
-                self.log.info("Uploading memory-blob to object store: dst=%r", key)
-                storage.store_file_from_memory(key, file_to_transfer["blob"], metadata=file_to_transfer["metadata"])
+            unlink_local = file_to_transfer.remove_after_upload
+            # Basebackups may be multipart uploads, depending on the driver.
+            # Swift needs to know about this so it can do possible cleanups.
+            # FIXME: make it more obvious what is happening here, since nothing
+            # seems to be specific to multipart here ?
+            multipart = file_to_transfer.filetype in {
+                FileType.Basebackup, FileType.Basebackup_chunk, FileType.Basebackup_delta
+            }
+            self.log.info("Uploading file to object store: src=%r dst=%r", file_to_transfer.source_data, key)
+            if not isinstance(file_to_transfer.source_data, BytesIO):
+                f = open(file_to_transfer.source_data, "rb")
             else:
-                # Basebackups may be multipart uploads, depending on the driver.
-                # Swift needs to know about this so it can do possible cleanups.
-                multipart = file_to_transfer["filetype"] in {"basebackup", "basebackup_chunk", "basebackup_delta"}
-                try:
-                    self.log.info("Uploading file to object store: src=%r dst=%r", file_to_transfer["local_path"], key)
-                    storage.store_file_from_disk(
-                        key, file_to_transfer["local_path"], metadata=file_to_transfer["metadata"], multipart=multipart
-                    )
-                    unlink_local = True
-                except LocalFileIsRemoteFileError:
-                    pass
+                f = file_to_transfer.source_data
+            with f:
+                storage.store_file_object(key, f, metadata=file_to_transfer.metadata)
             if unlink_local:
                 try:
-                    self.log.info("Deleting file: %r since it has been uploaded", file_to_transfer["local_path"])
-                    os.unlink(file_to_transfer["local_path"])
-                    metadata_path = file_to_transfer["local_path"] + ".metadata"
-                    with suppress(FileNotFoundError):
-                        os.unlink(metadata_path)
+                    self.log.info("Deleting file: %r since it has been uploaded", file_to_transfer.source_data)
+                    os.unlink(file_to_transfer.source_data)
+                    # If we're working from pathes, then compute the .metadata
+                    # path.
+                    # FIXME: should be part of the event itself
+                    if isinstance(file_to_transfer.source_data, Path):
+                        metadata_path = file_to_transfer.source_data.with_name(
+                            file_to_transfer.source_data.name + ".metadata"
+                        )
+                        with suppress(FileNotFoundError):
+                            os.unlink(metadata_path)
                 except Exception as ex:  # pylint: disable=broad-except
-                    self.log.exception("Problem in deleting file: %r", file_to_transfer["local_path"])
+                    self.log.exception("Problem in deleting file: %r", file_to_transfer.source_data)
                     self.metrics.unexpected_exception(ex, where="handle_upload_unlink")
-            return {"success": True, "opaque": file_to_transfer.get("opaque")}
+            return CallbackEvent(success=True, payload=payload)
         except Exception as ex:  # pylint: disable=broad-except
-            if file_to_transfer.get("retry_number", 0) > 0:
-                self.log.exception("Problem in moving file: %r, need to retry", file_to_transfer["local_path"])
+            if file_to_transfer.retry_number > 0:
+                self.log.exception("Problem in moving file: %r, need to retry", file_to_transfer.source_data)
                 # Ignore the exception the first time round as some object stores have frequent Internal Errors
                 # and the upload usually goes through without any issues the second time round
                 self.metrics.unexpected_exception(ex, where="handle_upload")
             else:
                 self.log.warning(
-                    "Problem in moving file: %r, need to retry (%s: %s)", file_to_transfer["local_path"],
+                    "Problem in moving file: %r, need to retry (%s: %s)", file_to_transfer.source_data,
                     ex.__class__.__name__, ex
                 )
-
-            file_to_transfer["retry_number"] = file_to_transfer.get("retry_number", 0) + 1
-            if file_to_transfer["retry_number"] > self.config["upload_retries_warning_limit"]:
+            file_to_transfer = dataclasses.replace(file_to_transfer, retry_number=file_to_transfer.retry_number + 1)
+            if file_to_transfer.retry_number > self.config["upload_retries_warning_limit"]:
                 create_alert_file(self.config, "upload_retries_warning")
 
             # Sleep for a bit to avoid busy looping. Increase sleep time if the op fails multiple times
-            self.sleep(min(0.5 * 2 ** (file_to_transfer["retry_number"] - 1), 20))
+            self.sleep(min(0.5 * 2 ** (file_to_transfer.retry_number - 1), 20))
 
             self.transfer_queue.put(file_to_transfer)
-            return {"success": False, "call_callback": False, "exception": ex}
+            return None

--- a/pghoard/wal.py
+++ b/pghoard/wal.py
@@ -49,14 +49,14 @@ class WalBlobLengthError(ValueError):
 WalHeader = namedtuple("WalHeader", ("version", "lsn"))
 
 
-def segments_per_xlogid(server_version: int) -> int:
+def segments_per_xlogid(server_version: Optional[int]) -> int:
     if server_version is not None and server_version < 90300:
         return 0x0FFFFFFFF // WAL_SEG_SIZE
     return 0x100000000 // WAL_SEG_SIZE
 
 
 class LSN:
-    def __init__(self, value: Union[int, str], server_version: int, timeline_id: Optional[int] = None):
+    def __init__(self, value: Union[int, str], server_version: Optional[int], timeline_id: Optional[int] = None):
         self.timeline_id = timeline_id
         self.server_version = server_version
         if isinstance(value, int):
@@ -149,7 +149,7 @@ class LSN:
 
     def __sub__(self, other) -> int:
         if isinstance(other, LSN):
-            self._assert_sane_for_comparison(self, other)
+            self._assert_sane_for_comparison(other)
             val = other.lsn
         elif isinstance(other, int):
             val = other
@@ -198,7 +198,7 @@ def read_header(blob):
     return WalHeader(version=version, lsn=lsn)
 
 
-def lsn_from_sysinfo(sysinfo: tuple, pg_version: str = None) -> LSN:
+def lsn_from_sysinfo(sysinfo: tuple, pg_version: Optional[int] = None) -> LSN:
     """Get wal file name out of a IDENTIFY_SYSTEM tuple
     """
     return LSN(sysinfo[2], timeline_id=int(sysinfo[1]), server_version=pg_version)

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -230,7 +230,7 @@ LABEL: pg_basebackup base backup
         }
         pghoard.create_basebackup(pghoard.test_site, db.user, basebackup_path, q, metadata)
         result = q.get(timeout=60)
-        assert result["success"]
+        assert result.success
 
         # make sure it shows on the list
         Restore().run([

--- a/test/test_wal_file_deleter.py
+++ b/test/test_wal_file_deleter.py
@@ -1,13 +1,15 @@
 # Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
 
 import time
+from pathlib import Path
 from queue import Queue
 
 import mock
 import pytest
 
 from pghoard import metrics
-from pghoard.compressor import WALFileDeleterThread
+from pghoard.common import QuitEvent
+from pghoard.compressor import WALFileDeleterThread, WalFileDeletionEvent
 
 
 # too fool the
@@ -31,16 +33,12 @@ def fixture_wal_file_deleter(mocker):
     deleter.start()
     yield deleter
     deleter.running = False
-    deleter_queue.put({"type": "QUIT"})
+    deleter_queue.put(QuitEvent)
     deleter.join()
 
 
 def make_event(path: str, site: str = "a"):
-    return {
-        "type": "delete_file",
-        "site": site,
-        "local_path": path,
-    }
+    return WalFileDeletionEvent(backup_site_key=site, file_path=Path(path))
 
 
 TEST_WAIT_TIME = 0.1
@@ -51,91 +49,50 @@ def test_wal_file_deleter_happy_path(wal_file_deleter: WALFileDeleterThreadPatch
     wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001"))
     time.sleep(TEST_WAIT_TIME)
     assert len(wal_file_deleter.to_be_deleted_files["a"]) == 1
-    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000001"}
+    assert wal_file_deleter.to_be_deleted_files["a"] == {Path("AA000001")}
     wal_file_deleter.os_unlink_mock.assert_not_called()
 
     wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000002"))
     time.sleep(TEST_WAIT_TIME)
     assert len(wal_file_deleter.to_be_deleted_files["a"]) == 1
-    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000002"}
-    wal_file_deleter.os_unlink_mock.assert_called_once_with("AA000001")
+    assert wal_file_deleter.to_be_deleted_files["a"] == {Path("AA000002")}
+    wal_file_deleter.os_unlink_mock.assert_called_once_with(Path("AA000001"))
 
     wal_file_deleter.os_unlink_mock.reset_mock()
     wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001"))
     time.sleep(TEST_WAIT_TIME)
     assert len(wal_file_deleter.to_be_deleted_files["a"]) == 1
-    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000002"}
-    wal_file_deleter.os_unlink_mock.assert_called_once_with("AA000001")
+    assert wal_file_deleter.to_be_deleted_files["a"] == {Path("AA000002")}
+    wal_file_deleter.os_unlink_mock.assert_called_once_with(Path("AA000001"))
 
     # Even if there are multiple files in the list, we delete all but the latest
     wal_file_deleter.os_unlink_mock.reset_mock()
-    wal_file_deleter.to_be_deleted_files["a"].add("AA000004")
-    wal_file_deleter.to_be_deleted_files["a"].add("AA000003")
+    wal_file_deleter.to_be_deleted_files["a"].add(Path("AA000004"))
+    wal_file_deleter.to_be_deleted_files["a"].add(Path("AA000003"))
     wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001"))
     time.sleep(TEST_WAIT_TIME)
     assert len(wal_file_deleter.to_be_deleted_files["a"]) == 1
-    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000004"}
+    assert wal_file_deleter.to_be_deleted_files["a"] == {Path("AA000004")}
     assert wal_file_deleter.os_unlink_mock.call_count == 3
 
 
 def test_survive_problems(wal_file_deleter: WALFileDeleterThreadPatched):
-
-    # We survive a non-existing local_path attribute
-    wal_file_deleter.wal_file_deletion_queue.put({
-        "type": "delete_file",
-        "site": "a",
-        "local_path_MISSING": "path",
-    })
-    time.sleep(TEST_WAIT_TIME)
-    assert len(wal_file_deleter.to_be_deleted_files) == 0
-    assert wal_file_deleter.running
-
-    # we have to have a type
-    wal_file_deleter.wal_file_deletion_queue.put({
-        "type_MISSING": "delete_file",
-        "site": "a",
-        "local_path": "AA000001",
-    })
-    time.sleep(TEST_WAIT_TIME)
-    assert wal_file_deleter.running
-    assert len(wal_file_deleter.to_be_deleted_files) == 0
-
-    # the type does matter
-    wal_file_deleter.wal_file_deletion_queue.put({
-        "type": "DOES MATTER",
-        "site": "a",
-        "local_path": "AA000001",
-    })
-    time.sleep(TEST_WAIT_TIME)
-    assert wal_file_deleter.running
-    assert len(wal_file_deleter.to_be_deleted_files) == 0
-
-    # site must not be missing
-    wal_file_deleter.wal_file_deletion_queue.put({
-        "type": "delete_file",
-        "site_MISSING": "a",
-        "local_path": "AA000001",
-    })
-    time.sleep(TEST_WAIT_TIME)
-    assert wal_file_deleter.running
-    assert len(wal_file_deleter.to_be_deleted_files) == 0
-
     # Adding the same path twice will still result in that file not deleted
     wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001"))
     wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001"))
     time.sleep(TEST_WAIT_TIME)
-    assert wal_file_deleter.running
+    assert wal_file_deleter.is_alive()
     wal_file_deleter.os_unlink_mock.assert_not_called()
     assert len(wal_file_deleter.to_be_deleted_files["a"]) == 1
-    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000001"}
+    assert wal_file_deleter.to_be_deleted_files["a"] == {Path("AA000001")}
 
     # we survive not finding the file during deletion and the to be deleted ("older") file is still removed from the queue
     wal_file_deleter.os_unlink_mock.side_effect = FileNotFoundError("foo")
     wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000002"))
     time.sleep(TEST_WAIT_TIME)
-    assert wal_file_deleter.running
+    assert wal_file_deleter.is_alive()
     assert len(wal_file_deleter.to_be_deleted_files["a"]) == 1
-    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000002"}
+    assert wal_file_deleter.to_be_deleted_files["a"] == {Path("AA000002")}
 
 
 def test_multiple_sites(wal_file_deleter: WALFileDeleterThreadPatched):
@@ -147,8 +104,8 @@ def test_multiple_sites(wal_file_deleter: WALFileDeleterThreadPatched):
     assert wal_file_deleter.running
     wal_file_deleter.os_unlink_mock.assert_not_called()
     assert len(wal_file_deleter.to_be_deleted_files) == 2
-    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000001"}
-    assert wal_file_deleter.to_be_deleted_files["b"] == {"AA000001"}
+    assert wal_file_deleter.to_be_deleted_files["a"] == {Path("AA000001")}
+    assert wal_file_deleter.to_be_deleted_files["b"] == {Path("AA000001")}
 
     # advance one site
     wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000002", site="a"))
@@ -156,8 +113,8 @@ def test_multiple_sites(wal_file_deleter: WALFileDeleterThreadPatched):
     assert wal_file_deleter.running
     assert wal_file_deleter.os_unlink_mock.call_count == 1
     assert len(wal_file_deleter.to_be_deleted_files) == 2
-    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000002"}
-    assert wal_file_deleter.to_be_deleted_files["b"] == {"AA000001"}
+    assert wal_file_deleter.to_be_deleted_files["a"] == {Path("AA000002")}
+    assert wal_file_deleter.to_be_deleted_files["b"] == {Path("AA000001")}
 
     # Should do nothing
     wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001", site="b"))
@@ -165,8 +122,8 @@ def test_multiple_sites(wal_file_deleter: WALFileDeleterThreadPatched):
     assert wal_file_deleter.running
     assert wal_file_deleter.os_unlink_mock.call_count == 1
     assert len(wal_file_deleter.to_be_deleted_files) == 2
-    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000002"}
-    assert wal_file_deleter.to_be_deleted_files["b"] == {"AA000001"}
+    assert wal_file_deleter.to_be_deleted_files["a"] == {Path("AA000002")}
+    assert wal_file_deleter.to_be_deleted_files["b"] == {Path("AA000001")}
 
     # now advance it on site b
     wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000003", site="b"))
@@ -174,13 +131,13 @@ def test_multiple_sites(wal_file_deleter: WALFileDeleterThreadPatched):
     assert wal_file_deleter.running
     #assert wal_file_deleter.os_unlink_mock.call_count == 2
     assert len(wal_file_deleter.to_be_deleted_files) == 2
-    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000002"}
-    assert wal_file_deleter.to_be_deleted_files["b"] == {"AA000003"}
+    assert wal_file_deleter.to_be_deleted_files["a"] == {Path("AA000002")}
+    assert wal_file_deleter.to_be_deleted_files["b"] == {Path("AA000003")}
 
     wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000001", site="c"))
     wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000002", site="c"))
     wal_file_deleter.wal_file_deletion_queue.put(make_event("AA000003", site="c"))
     time.sleep(TEST_WAIT_TIME)
-    assert wal_file_deleter.to_be_deleted_files["a"] == {"AA000002"}
-    assert wal_file_deleter.to_be_deleted_files["b"] == {"AA000003"}
-    assert wal_file_deleter.to_be_deleted_files["c"] == {"AA000003"}
+    assert wal_file_deleter.to_be_deleted_files["a"] == {Path("AA000002")}
+    assert wal_file_deleter.to_be_deleted_files["b"] == {Path("AA000003")}
+    assert wal_file_deleter.to_be_deleted_files["c"] == {Path("AA000003")}

--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -123,7 +123,7 @@ class TestWebServer:
         pghoard.config["backup_sites"][pghoard.test_site]["basebackup_mode"] = mode
         pghoard.create_basebackup(pghoard.test_site, db.user, basebackup_path, q)
         result = q.get(timeout=60)
-        assert result["success"]
+        assert result.success
         backups_after = set(f for f in os.listdir(backup_dir) if not f.endswith(".metadata"))
         new_backups = backups_after - backups_before
         assert len(new_backups) == 1


### PR DESCRIPTION
Previously, queue events were dict, with different keys meaning
different things.

Refactor this to use specific events for each type of queues. The main
benefit is to standardize the use of pathes, and not have every module
(compressor, transfer) responsible for guessing the file destination
based on it's name or path or whatever. This will allow us to handle
more easily different types of files as proposed in the tentative v3
backup format, and to implement more steps in the compression / transfer
pipeline.

The actual file data is now stored in a source_data field, which can be
a Path or a BytesIO. This will allow us to use different temp storage
strategies more easily too (TemporarySpoolFile, NamedPipe, BytesIO,
NamedTemporaryFile...).