### PR TITLE
Reduce timeout when polling pg_receivewal stdout/err.

### DIFF
--- a/pghoard/receivexlog.py
+++ b/pghoard/receivexlog.py
@@ -61,7 +61,7 @@ class PGReceiveXLog(Thread):
         self.pid = proc.pid
         self.log.info("Started: %r, running as PID: %r", command, self.pid)
         while self.running:
-            rlist, _, _ = select.select([proc.stdout, proc.stderr], [], [], 1.0)
+            rlist, _, _ = select.select([proc.stdout, proc.stderr], [], [], min(1.0, self.disk_space_check_interval))
             for fd in rlist:
                 content = fd.read()
                 if content:


### PR DESCRIPTION
As evidenced by the flaky tests in #489, the timeout for polling
pg_receivewal stderr and stdout was too high: due to buffering on the
process stdout / stderr, we could end in a situation were WAL segment
were produced, and disk was starting to fill, while the pghoard thread
did not read anything from the process for the whole timeout and thus
did not have a chance to detect the disk filling up.

In normal operation it shouldn't matter much, since the default value
for disk_space_check_interval is 10s, but during tests it matters.

So reduce the timeout to min(1, disk_space_check_interval)

Fixes #489 