### PR TITLE
allow using socks5h too as proxy type

### DIFF
--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -63,8 +63,8 @@ class S3Transfer(BaseTransfer):
                     auth = ""
                 host = proxy_info["host"]
                 port = proxy_info["port"]
-                if proxy_info.get("type") == "socks5":
-                    schema = "socks5"
+                if proxy_info.get("type") in {"socks5", "socks5h"}:
+                    schema = proxy_info.get("type")
                 else:
                     schema = "http"
                 proxy_url = f"{schema}://{auth}{host}:{port}"


### PR DESCRIPTION
this gets passed to "requests" library which ends up doing the correct
thing. (resolve destintaion address via remote (proxy) and not on host)