### PR TITLE
Fix removal of delta backup

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -342,7 +342,8 @@ class PGHoard:
         keep_hexdigests = set()
 
         basebackup_data_files = list()
-        for backup_name in [basebackup_name_to_delete] + [back["name"] for back in backups_to_keep]:
+        delta_backups_to_keep = filter(lambda x: x["metadata"]["format"] == BaseBackupFormat.delta_v1, backups_to_keep)
+        for backup_name in [basebackup_name_to_delete] + [back["name"] for back in delta_backups_to_keep]:
             delta_backup_key = os.path.join(self._get_site_prefix(site), "basebackup", backup_name)
             bmeta_compressed = storage.get_contents_to_string(delta_backup_key)[0]
             with rohmufile.file_reader(


### PR DESCRIPTION
Exclude non delta basebackups from iteration when listing delta basebackup files for removal.
In case if different types of backups were used cleanup might not work due to this bug and it will break pghoard