### PR TITLE
Add github issue teamplates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_question.md
+++ b/.github/ISSUE_TEMPLATE/01_question.md
@@ -1,0 +1,13 @@
+---
+name: ❓ Ask a question
+about: Got stuck or missing something from the docs? Ask away!
+---
+
+# What can we help you with?
+
+<!-- Try to explain your question with as much detail as you can provide. -->
+
+# Where would you expect to find this information?
+
+<!-- Feel free to point us where with links or even proposing new sections or pages in the documentation. -->
+

--- a/.github/ISSUE_TEMPLATE/02_bug.md
+++ b/.github/ISSUE_TEMPLATE/02_bug.md
@@ -1,0 +1,17 @@
+---
+name: 🐜 Report a bug
+about: Spotted a problem? Let us know
+---
+
+# What happened?
+
+<!-- Try to be as precise as possible. If you can a small reproducer example would be great! -->
+
+# What did you expect to happen?
+
+<!-- Please explain what would be the expected behavior for this particular case, ideally, with examples. -->
+
+# What else do we need to know?
+
+<!-- Include your platform, version, and any other information that seems relevant. -->
+

--- a/.github/ISSUE_TEMPLATE/03_feature.md
+++ b/.github/ISSUE_TEMPLATE/03_feature.md
@@ -1,0 +1,16 @@
+---
+name: 💡 Feature suggestion
+about: What would make this even better?
+---
+
+# What is currently missing?
+
+<!-- Please, describe what is currently missing and why should it be present in the project. -->
+
+# How could this be improved?
+
+<!-- If you already know how this could be approached, please provide some brief explanation about it. -->
+
+# Is this a feature you would work on yourself?
+
+* [ ] I plan to open a pull request for this feature

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Aiven Security Bug Bounty
+    url: https://hackerone.com/aiven_ltd
+    about: Our bug bounty program.


### PR DESCRIPTION
Adding GitHub issue templates this makes the issue creation more meaningful and offers a step of curation already from the start.