### PR TITLE
fix incorrect filetype for timeline file

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -61,8 +61,8 @@ class InotifyAdapter:
     def adapt_event(self, inotify_event):
         full_path = Path(inotify_event["full_path"])
         backup_site_name = self.path_to_site[inotify_event["watched_path"]]
-        # Ignore .partial files
-        if full_path.suffix == ".partial":
+        # Ignore .partial and .tmp files
+        if full_path.suffix in {".partial", ".tmp"}:
             return None
         if full_path.suffix == ".history":
             filetype = FileType.Timeline

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -572,9 +572,12 @@ class PGHoard:
                 if not wal.WAL_RE.match(filename) and not wal.TIMELINE_RE.match(filename):
                     self.log.warning("Found invalid file %r from incoming xlog directory", full_path)
                     continue
+
+                filetype = FileType.Timeline if wal.TIMELINE_RE.match(filename) else FileType.Wal
+
                 compression_event = CompressionEvent(
-                    file_type=FileType.Wal,
-                    file_path=FileTypePrefixes[FileType.Wal] / filename,
+                    file_type=filetype,
+                    file_path=FileTypePrefixes[filetype] / filename,
                     delete_file_after_compression=True,
                     backup_site_name=site,
                     source_data=Path(full_path),


### PR DESCRIPTION
Incorrect filetype in the `CompressionEvent` for timeline file would cause the pghoard to crash.