### PR TITLE
Support azure service principal authentication

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ python-dateutil
 python-snappy
 python-systemd 
 requests
+azure-identity
 azure-storage-blob==2.1.0
 paramiko
 zstandard


### PR DESCRIPTION
AzureTransfer currently only authenticates using a
Service Account name and secret, which does not allow
for granular permissions. Adding service principal
authentication to allow more restrictive permissions.