### PR TITLE
s3: increase chunk size

### DIFF
--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -19,8 +19,8 @@ from .base import (KEY_TYPE_OBJECT, KEY_TYPE_PREFIX, BaseTransfer, IterKeyItem, 
 
 def calculate_chunk_size():
     total_mem_mib = get_total_memory() or 0
-    # At least 5 MiB, at most 524 MiB. Max block size used for hosts with ~300+ GB of memory
-    return max(min(int(total_mem_mib / 600), 524), 5) * 1024 * 1024
+    # At least 5 MiB, at most 524 MiB. Max block size used for hosts with ~210+ GB of memory
+    return max(min(int(total_mem_mib / 400), 524), 5) * 1024 * 1024
 
 
 def get_proxy_url(proxy_info):


### PR DESCRIPTION
On certain machine specs, current configuration could mean you end up with too small chunk sizes, meaning total amount of chunks would exceed 10k+, which is the maximum amount s3 will allow.

This adjustment will generate slightly larger chunk sizes which should correct the issue