### PR TITLE
RFC: compressor, transfer: add metrics about oldest non-uploaded backup data [BF-962]

### DIFF
--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from queue import Empty
 from tempfile import NamedTemporaryFile
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 import psycopg2
 
@@ -370,7 +370,7 @@ class PGBaseBackup(PGHoardThread):
             )
         )
 
-    def parse_backup_label(self, backup_label_data):
+    def parse_backup_label(self, backup_label_data: Union[str, bytes]) -> Tuple[str, str]:
         if isinstance(backup_label_data, str):
             backup_label_data = backup_label_data.encode("utf-8")
         for line in backup_label_data.split(b"\n"):

--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -27,7 +27,6 @@ import psycopg2
 
 from pghoard.compressor import CompressionEvent
 from pghoard.rohmu import dates, errors, rohmufile
-
 # pylint: disable=superfluous-parens
 from . import common, version, wal
 from .basebackup_delta import DeltaBaseBackup

--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -162,7 +162,7 @@ class CompressorThread(PGHoardThread):
                     raise
         self.log.debug("Quitting Compressor")
 
-    def handle_decompression_event(self, event):
+    def handle_decompression_event(self, event: DecompressionEvent) -> None:
         with open(event.destination_path, "wb") as output_obj:
             rohmufile.read_file(
                 input_obj=event.source_data,
@@ -175,7 +175,7 @@ class CompressorThread(PGHoardThread):
         if event.callback_queue:
             event.callback_queue.put(CallbackEvent(success=True))
 
-    def handle_event(self, event):
+    def handle_event(self, event: CompressionEvent) -> bool:
         # pylint: disable=redefined-variable-type
         file_type = event.file_type
         rsa_public_key = None


### PR DESCRIPTION
This is a draft, PoC implementation.

While trying to solve [BF-962] we thought that the actual metric we'd like is not the time since the latest upload of some chunk of our backups, but the time since the oldest non-uploaded backup chunk, because large backup parts could be non-working if we've got gaps.

Backup Label: as defined in PGHoard, this is a (start-wal-segment, start-time) tuple

This PoC (not configured to work currently, null implementation in place to run tests) would work this way:
* When we see a backup label for a segment on the machine side, keep track of it
* When we see a backup label that was correctly uploaded to our external object storage, stop keeping track of it
* Periodically, send a metric about the oldest backup label we're keeping track of

FIXMEs, TODOs, THINKABOUTs
* keep seend sorted someway / use a sorted set so we shouldn't re-sort everytime we manipulate the set
* consider whether we want to send metrics only on seen, only on uploaded, or in both cases, or periodically
* refactor/remove duplication (just copypasted right now)
* check if our actual Metrics implementations are blocking (are we slowing down/indirectly synchronizing
  threads with this kind of implementation) and threadsafe (but if they aren't we have other problems as well).
* since we rely heavily on a couple of info that are currently metadata (start-wal-segment and start-time) maybe
   those should become actual event attributes 
* For this draft I signaled the "seen" when handling the compression event, but this could actually be moved to
  the places where the CompressionEvent is added to the compression queue
* Naming:  ThreadSafeCompressorMetadataNotifier should be something like "BackupLabelNotifier"
* Make sure the notify* methods never throw, and never block (unless lock is held)



[BF-962]: https://aiven.atlassian.net/browse/BF-962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ