### PR TITLE
Support azure SAS authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,5 +68,5 @@ build-dep-fed:
 		python3-botocore python3-cryptography python3-paramiko python3-dateutil python3-devel \
 		python3-flake8 python3-psycopg2 python3-pylint python3-pytest python3-execnet python3-pytest-mock \
 		python3-pytest-cov python3-requests python3-snappy \
-		python3-azure-sdk \
+		python3-azure-common python3-azure-core python3-azure-storage-blob \
 		rpm-build

--- a/README.rst
+++ b/README.rst
@@ -808,7 +808,10 @@ Optional keys for Amazon Web Services S3:
 * ``azure`` for Microsoft Azure Storage, required configuration keys:
 
  * ``account_name`` for the name of the Azure Storage account
- * ``account_key`` for the secret key of the Azure Storage account
+ * One of:
+  * ``account_key`` to authenticate using an Azure Storage account key
+  * ``sas_token`` to authenticate using a SAS token.
+
  * ``bucket_name`` for the name of Azure Storage container used to store
    objects
  * ``azure_cloud`` Azure cloud selector, ``"public"`` (default) or ``"germany"``

--- a/pghoard.spec
+++ b/pghoard.spec
@@ -5,6 +5,9 @@ Url:            http://github.com/aiven/pghoard
 Summary:        PostgreSQL streaming backup service
 License:        ASL 2.0
 Source0:        pghoard-rpm-src.tar
+Requires:       python3-azure-common
+Requires:       python3-azure-core
+Requires:       python3-azure-storage-blob
 Requires:       python3-botocore
 Requires:       python3-cryptography >= 0.8
 Requires:       python3-dateutil

--- a/test/test_storage.py
+++ b/test/test_storage.py
@@ -401,6 +401,22 @@ def test_storage_azure_with_prefix(tmpdir):
     _test_storage_init("azure", True, tmpdir)
 
 
+def test_storage_azure_no_prefix_dynamic(tmpdir):
+    try:
+        config_overrides = getattr(test_storage_configs, "config_azure_dynamic")
+        _test_storage_init("azure", False, tmpdir, config_overrides=config_overrides())
+    except AttributeError:
+        pytest.skip("config_azure_dynamic config isn't available")
+
+
+def test_storage_azure_with_prefix_dynamic(tmpdir):
+    try:
+        config_overrides = getattr(test_storage_configs, "config_azure_dynamic")
+        _test_storage_init("azure", True, tmpdir, config_overrides=config_overrides())
+    except AttributeError:
+        pytest.skip("config_azure_dynamic config isn't available")
+
+
 def test_storage_ceph_s3_no_prefix(tmpdir):
     _test_storage_init("ceph_s3", False, tmpdir)
 


### PR DESCRIPTION
AzureTransfer currently only authenticates using a Service Account name and secret, which provides the client access to all resources contained within the authenticated storage account. This PR adjusts the AzureTransfer client to optionally authenticate via a Shared Access Signature (see [Azure docs](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview)), which can be assigned more granular and restrictive permissions (i.e. at the container or blob level rather than at the storage account level). 