### PR TITLE
github: push any commits from the main branch to master

### DIFF
--- a/.github/workflows/sync-main-and-master.yml
+++ b/.github/workflows/sync-main-and-master.yml
@@ -1,0 +1,20 @@
+name: "Sync master from main"
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync_master_from_main:
+    runs-on: ubuntu-latest
+    name: Sync master from main
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Push to master
+        run: git push origin main:master


### PR DESCRIPTION
An automated workflow for keeping `main` and `master` sync after we rename
the default branch to `main`.

Should help avoid breakage elsewhere where we might have dependencies on the
`master` name.  The workflow and `master` branch should be deleted after a
while when everything has migrated over to `main`.