### PR TITLE
Documentation and test matrix updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        pg-version: [9.6, 10, 11, 12, 13, 14]
+        pg-version: [10, 11, 12, 13, 14]
 
     steps:
       - id: checkout-code

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,20 @@
+pghoard DEV
+===========
+
+* Support for PostgreSQL version 14
+* Major improvements for delta backup support
+* Improve robustness of the Swift backend
+* Testing and CI improvements
+
+pghoard 2.2.0 (2021-04-12)
+==========================
+
+* Support for PostgreSQL versions 12 and 13
+* Support for more flexible basebackup scheduling
+* Testing and CI improvements
+* Initial support for delta basebackups
+* Security fixes for tar extraction
+
 pghoard 2.1.0 (2019-05-27)
 ==========================
 

--- a/README.rst
+++ b/README.rst
@@ -78,9 +78,11 @@ if the host running PGHoard is incapacitated.
 Requirements
 ============
 
-PGHoard can backup and restore PostgreSQL versions 9.3 and above.  The
-daemon is implemented in Python and works with CPython version 3.5 or newer.
-The following Python modules are required:
+PGHoard can backup and restore PostgreSQL versions 9.3 and above, but is
+only tested and actively developed with version 10 and above.
+
+The daemon is implemented in Python and is tested and developed with version
+3.6 and above. The following Python modules are required:
 
 * psycopg2_ to look up transaction log metadata
 * requests_ for the internal client-server architecture

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,7 +42,7 @@ Vagrant.configure("2") do |config|
         sed -i "s/^#create_main_cluster.*/create_main_cluster=false/g" /etc/postgresql-common/createcluster.conf
 
         apt-get install -y python3.6 python3.6-dev python3.6-venv python3.7 python3.7-dev python3.7-venv python3.8 python3.8-dev python3.8-venv python3.9 python3.9-dev python3.9-venv
-        apt-get install -y postgresql-{9.6,10,11,12,13,14} postgresql-server-dev-{9.6,10,11,12,13,14}
+        apt-get install -y postgresql-{10,11,12,13,14} postgresql-server-dev-{10,11,12,13,14}
 
         username="$(< /dev/urandom tr -dc a-z | head -c${1:-32};echo;)"
         password=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32};echo;)

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -4,8 +4,12 @@ Development
 Requirements
 ------------
 
-PGHoard can backup and restore PostgreSQL versions 9.3 and above.  The
-daemon is implemented in Python and works with CPython version 3.5 or newer.
+PGHoard can backup and restore PostgreSQL versions 9.3 and above, but is
+only tested and actively developed with version 10 and above.
+
+The daemon is implemented in Python and is tested and developed with version
+3.6 and above. The following Python modules are required:
+
 The following Python modules are required:
 
 * psycopg2_ to look up transaction log metadata
@@ -50,24 +54,16 @@ Vagrant
 =======
 
 The Vagrantfile can be used to setup a vagrant development environment.   The vagrant environment has
-python 3.6, 3.7, 3.8 and 3.9 virtual environments and installations of postgresql 9.6, 10, 11 and 12.
+python 3.6, 3.7, 3.8 and 3.9 virtual environments and installations of postgresql 10 and newer.
 
 By default vagrant up will start a Virtualbox environment.   The Vagrantfile will also work for libvirt, just prefix
 VAGRANT_DEFAULT_PROVIDER=libvirt to the vagrant up command.
-
-Any combination of Python (3.6, 3.7 and 3.8) and Postgresql (9.6, 10, 11 and 12)
 
 Bring up vagrant instance and connect via ssh::
 
 vagrant up
 vagrant ssh
 vagrant@ubuntu2004:~$ cd /vagrant
-
-Test with Python 3.6 and Postgresql 9.6
-
-vagrant@ubuntu2004:~$ source ~/venv3.6/bin/activate
-vagrant@ubuntu2004:~$ PG_VERSION=9.6 make unittest
-vagrant@ubuntu2004:~$ deactivate
 
 Test with Python 3.7 and Postgresql 10
 

--- a/pghoard.spec
+++ b/pghoard.spec
@@ -5,11 +5,21 @@ Url:            http://github.com/aiven/pghoard
 Summary:        PostgreSQL streaming backup service
 License:        ASL 2.0
 Source0:        pghoard-rpm-src.tar
+Requires:       python3-botocore
+Requires:       python3-cryptography >= 0.8
+Requires:       python3-dateutil
+Requires:       python3-psycopg2
+Requires:       python3-pydantic
+Requires:       python3-requests
+Requires:       python3-snappy
+Requires:       python3-zstandard
 Requires:       systemd
-Requires:       python3-botocore, python3-cryptography >= 0.8, python3-dateutil
-Requires:       python3-psycopg2, python3-requests, python3-snappy, python3-zstandard, python3-pydantic,
-Conflicts:      pgespresso92 < 1.2, pgespresso93 < 1.2, pgespresso94 < 1.2, pgespresso95 < 1.2
-BuildRequires:  python3-flake8, python3-pytest, python3-pylint, python3-devel, golang
+Conflicts:      pgespresso93 < 1.2, pgespresso94 < 1.2, pgespresso95 < 1.2
+BuildRequires:  golang
+BuildRequires:  python3-devel
+BuildRequires:  python3-flake8
+BuildRequires:  python3-pylint
+BuildRequires:  python3-pytest
 
 %undefine _missing_build_ids_terminate_build
 %define debug_package %{nil}


### PR DESCRIPTION
No need to test PG 9.6 anymore. Clarify supported/tested versions elsewhere while at it.