### PR TITLE
Use the term "primary" for HA roles

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -244,7 +244,7 @@ installation.
      CREATE USER pghoard PASSWORD 'putyourpasswordhere' REPLICATION;
 
 2. Edit the local ``pg_hba.conf`` to allow access for the newly created
-   account to the ``replication`` database from the master and standby
+   account to the ``replication`` database from the primary and standby
    nodes. For example::
 
      # TYPE  DATABASE     USER     ADDRESS       METHOD
@@ -256,7 +256,7 @@ installation.
 
    or by sending directly a ``SIGHUP`` to the PostgreSQL ``postmaster`` process.
 
-3. Fill in the created user account and master/standby addresses into the
+3. Fill in the created user account and primary/standby addresses into the
    configuration file ``pghoard.json`` to the section ``backup_sites``.
 
 4. Fill in the possible object storage user credentials into the
@@ -365,7 +365,7 @@ If we'd want to restore to the latest point in time we could fetch the
 required basebackup by running::
 
   pghoard_restore get-basebackup --config /var/lib/pghoard/pghoard.json \
-      --target-dir /var/lib/pgsql/9.5/data --restore-to-master
+      --target-dir /var/lib/pgsql/9.5/data --restore-to-primary
 
   Basebackup complete.
   You can start PostgreSQL by running pg_ctl -D foo start

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -113,7 +113,7 @@ If we'd want to restore to the latest point in time we could fetch the
 required basebackup by running::
 
   pghoard_restore get-basebackup --config pghoard.json \
-      --target-dir <destination> --restore-to-master
+      --target-dir <destination> --restore-to-primary
 
   Basebackup complete.
   You can start PostgreSQL by running pg_ctl -D foo start

--- a/pghoard/archive_sync.py
+++ b/pghoard/archive_sync.py
@@ -26,7 +26,7 @@ class ArchiveSync:
     """Iterate over WAL directory in reverse alphanumeric order and upload
     files to object storage until we find a file that already exists there.
     This can be used after a failover has happened to make sure the archive
-    has no gaps in case the previous master failed before archiving its
+    has no gaps in case the previous primary failed before archiving its
     final segment."""
     def __init__(self):
         self.log = logging.getLogger(self.__class__.__name__)
@@ -114,9 +114,9 @@ class ArchiveSync:
                         archive_type == "WAL" and (hash_checks_done < max_hash_checks or max_hash_checks < 0) and remote_hash
                     )
                     if archive_type == "WAL" and not remote_hash:
-                        # If we don't have hashes available (old pghoard was running on previous master), re-upload first
+                        # If we don't have hashes available (old pghoard was running on previous primary), re-upload first
                         # file that already exists in remote storage and doesn't have a checksum since it might be the last
-                        # WAL file of previous timeline uploaded by old master and invalid because it doesn't have the
+                        # WAL file of previous timeline uploaded by old primary and invalid because it doesn't have the
                         # timeline switch event and have some writes that are not valid for our timeline
                         existing_wal_without_checksum_count += 1
                         if existing_wal_without_checksum_count == 1:

--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -105,7 +105,7 @@ def create_recovery_conf(
     recovery_target_name=None,
     recovery_target_time=None,
     recovery_target_xid=None,
-    restore_to_master=None
+    restore_to_primary=None
 ):
     restore_command = [
         "pghoard_postgres_command",
@@ -136,7 +136,7 @@ def create_recovery_conf(
     ]
 
     use_recovery_conf = (pg_version < "12")  # no more recovery.conf in PG >= 12
-    if not restore_to_master:
+    if not restore_to_primary:
         if use_recovery_conf:
             lines.append("standby_mode = 'on'")
         else:
@@ -270,7 +270,12 @@ class Restore:
             cmd.add_argument("--recovery-target-name", help="PostgreSQL recovery_target_name", metavar="RESTOREPOINT")
             cmd.add_argument("--recovery-target-time", help="PostgreSQL recovery_target_time", metavar="ISO_TIMESTAMP")
             cmd.add_argument("--recovery-target-xid", help="PostgreSQL recovery_target_xid", metavar="XID")
-            cmd.add_argument("--restore-to-master", help="Restore the database to a PG master", action="store_true")
+            cmd.add_argument(
+                "--restore-to-primary",
+                "--restore-to-master",
+                help="Restore the database to a PG primary",
+                action="store_true"
+            )
 
         cmd = add_cmd(self.list_basebackups_http)
         host_port_args()
@@ -331,7 +336,7 @@ class Restore:
                 recovery_target_name=arg.recovery_target_name,
                 recovery_target_time=arg.recovery_target_time,
                 recovery_target_xid=arg.recovery_target_xid,
-                restore_to_master=arg.restore_to_master,
+                restore_to_primary=arg.restore_to_primary,
                 overwrite=arg.overwrite,
                 tablespace_mapping=tablespace_mapping,
                 tablespace_base_dir=arg.tablespace_base_dir,
@@ -441,7 +446,7 @@ class Restore:
         recovery_target_name=None,
         recovery_target_time=None,
         recovery_target_xid=None,
-        restore_to_master=None,
+        restore_to_primary=None,
         overwrite=False,
         tablespace_mapping=None,
         tablespace_base_dir=None
@@ -603,7 +608,7 @@ class Restore:
             recovery_target_name=recovery_target_name,
             recovery_target_time=recovery_target_time,
             recovery_target_xid=recovery_target_xid,
-            restore_to_master=restore_to_master,
+            restore_to_primary=restore_to_primary,
         )
 
         print("Basebackup restoration complete.")

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -531,7 +531,7 @@ LABEL: pg_basebackup base backup
                 pghoard.config_path,
                 "--site",
                 pghoard.test_site,
-                "--restore-to-master",
+                "--restore-to-primary",
                 "--target-dir",
                 backup_out,
                 "--tablespace-dir",

--- a/test/test_restore.py
+++ b/test/test_restore.py
@@ -120,7 +120,7 @@ class TestRecoveryConf(PGHoardTestCase):
         assert "primary_conninfo" in getdata()  # make sure it's there
         assert "''test''" in getdata()  # make sure it's quoted
         assert "standby_mode = 'on'" in getdata()
-        content = create_recovery_conf(td, "dummysite", primary_conninfo="dbname='test'", restore_to_master=True)
+        content = create_recovery_conf(td, "dummysite", primary_conninfo="dbname='test'", restore_to_primary=True)
         assert "primary_conninfo" in content
         assert "standby_mode = 'on'" not in content
         content = create_recovery_conf(

--- a/test/test_restore.py
+++ b/test/test_restore.py
@@ -100,6 +100,18 @@ class TestRecoveryConf(PGHoardTestCase):
         recovery_time = recovery_time.replace(tzinfo=datetime.timezone.utc)
         assert r._find_nearest_basebackup(recovery_time)["name"] == "2015-02-12_0"  # pylint: disable=protected-access
 
+    def test_compatible_cli_args(self):
+        parser = Restore().create_parser()
+
+        args_with_no_flag = ["get-basebackup", "--target-dir", "TARGET_DIR", "--config", "CONFIG"]
+        assert not parser.parse_args(args_with_no_flag).restore_to_primary
+
+        args_with_flag = parser.parse_args(args_with_no_flag + ["--restore-to-primary"])
+        assert args_with_flag.restore_to_primary
+
+        args_with_old_flag = parser.parse_args(args_with_no_flag + ["--restore-to-master"])
+        assert args_with_flag == args_with_old_flag
+
     def test_create_recovery_conf(self):
         td = self.temp_dir
         fn = os.path.join(td, "recovery.conf")


### PR DESCRIPTION
The [PostgreSQL glossary](https://www.postgresql.org/docs/13/glossary.html#GLOSSARY-PRIMARY-SERVER) prefers the terms primary/replica to refer to high availability roles.

I took the approach of changing all references, including argument names.  Can someone confirm whether there's a public API that needs to be maintained?

If I understand argparse, both the `--restore-from-master` and `--restore-from-primary` keys are accepted and equivalent.