### PR TITLE
Harden the GitHub Workflows [SECDEV-673]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build pghoard
 
+# Default to read-only access to all APIs.
+permissions: read-all
+
 on:
   push:
     branches:
@@ -21,6 +24,9 @@ jobs:
 
       - id: checkout-code
         uses: actions/checkout@v2
+        with:
+          # Do not persist the token during execution of this job.
+          persist-credentials: false
 
       - id: prepare-python
         uses: actions/setup-python@v2
@@ -84,6 +90,7 @@ jobs:
         run: make coverage
 
       - id: upload-codecov
-        uses: codecov/codecov-action@v2
+        # Third-party action pinned to v2.1.0
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b
         with:
           verbose: true

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -10,9 +10,35 @@ jobs:
     name: Sphinx Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: seanzhengw/sphinx-pages@d29427677b3b89c1b5311d9eb135fb4168f4ba4a
-        id: sphinx-pages
+      - name: "Checkout Main Branch"
+        uses: actions/checkout@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          create_readme: true
-          source_dir: docs/
+          persist-credentials: false
+          path: main
+          ref: main
+
+      - name: "Checkout GitHub Pages Branch"
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          path: gh-pages
+          ref: gh-pages
+
+      - name: "Setup Python & Install Spinx"
+        uses: actions/setup-python@v3
+
+      - name: "Install Sphinx & Theme"
+        run: pip install sphinx==4.5.0 sphinx-rtd-theme==1.0.0
+
+      - name: "Run Sphinx"
+        run: sphinx-build -b html main/docs gh-pages -E -d $GITHUB_WORKSPACE/.doctree
+
+      - name: "Commit & Push Changes (If Any)"
+        run: |
+          cd gh-pages
+          git add -A
+          git config --global user.email "$(git show --format=%ae -s)"
+          git config --global user.name "$(git show --format=%an -s)"
+          git commit -m "From $GITHUB_REF $(echo ${GITHUB_SHA} | cut -c 1-8)"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git push


### PR DESCRIPTION
This patch improves security around GitHub Workflows:

For the `build.yml` workflow:

 * Set the default workflow permissions to `read` - because this workflow does not need to modify anything in the project.
 * Do not let `actions/checkout` persist (write to disk) the GitHub token - because this workflow does not need to modify anything in the project.
 * Pin the `codecov/codecov-action` by commit hash instead of version tag - this lowers the chance of getting an unexpected version.

> (The fact that `actions/checkout` persists the `GITHUB_TOKEN` is pretty unexpected. Even if you do not explicitly do   `token: ${{ secrets.GITHUB_TOKEN }}`, the `token` will have a default value of `${{ github.token }}`, which is the exact same token. And since `persist-credentials` is `true` by default, any basic checkout writes the token to disk, ready for other steps to ~use~ steal it. Convenient because you can `git *` away, but also a really odd GitHub Actions design decision ...)

For the `sphinx.yml` workflow:

I rewrote this workflow in such a way that it does not depend on [https://github.com/seanzhengw/sphinx-pages](seanzhengw/sphinx-pages) anymore. Although we pinned that action, I noticed that it was not maintained anymore (repository archived). That action also does too many things and as a result it needs a full access `GITHUB_TOKEN`. I've created a new workflow with a minimal amount of steps that is hopefully easy to read. The main advantage of this new workflow is that there is no possibility of the `GITHUB_TOKEN` leaking to any third-party action or tool anymore.

No changes for `sync-main-and-master.yml` and `codeql-analysis.yml` because no third-party actions or code is involved.