### PR TITLE
Fix upload path for basebackup chunks [BF-1161]

### DIFF
--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -631,8 +631,7 @@ class PGBaseBackup(PGHoardThread):
             metadata.update(extra_metadata)
         # FIXME: handle the key computation before here
         chunk_path = Path(chunk_path)
-        base_repo = chunk_path.parent.parent.parent
-        chunk_name = chunk_path.relative_to(base_repo)
+        chunk_name = chunk_path.relative_to(chunk_path.parent.parent)
         if file_type == FileType.Basebackup_chunk:
             middle_path = Path("basebackup_chunk")
         elif file_type == FileType.Basebackup:
@@ -641,6 +640,9 @@ class PGBaseBackup(PGHoardThread):
         elif file_type == FileType.Basebackup_delta:
             middle_path = Path("basebackup_delta")
             chunk_name = chunk_name.name
+        else:
+            raise NotImplementedError(f"Unrecognizable file type: {file_type}")
+
         self.transfer_queue.put(
             UploadEvent(
                 callback_queue=callback_queue,

--- a/pghoard/wal.py
+++ b/pghoard/wal.py
@@ -214,6 +214,7 @@ def get_current_lsn_from_identify_system(conn_str: str) -> LSN:
     cur = conn.cursor()
     cur.execute("IDENTIFY_SYSTEM")
     sysinfo = cur.fetchone()
+    assert sysinfo
     conn.close()
     return lsn_from_sysinfo(sysinfo, pg_version)
 


### PR DESCRIPTION
Fix upload object path for basebackup chunks, instead of 
`/basebackup_chunk/a/2022-04-19_09-27_0/2022-04-19_09-27_0.00000001.pghoard`
it should be 
`/basebackup_chunk/2022-04-19_09-27_0/2022-04-19_09-27_0.00000001.pghoard`