### PR TITLE
tests: test all pg versions simultaneously

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        pg-version: [10, 11, 12, 13, 14]
+        python-version: [3.9, 3.8, 3.7, 3.6]
 
     steps:
       - id: checkout-code
@@ -78,8 +77,7 @@ jobs:
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
           # Setup build deps
-          sudo apt-get install -y libsnappy-dev
-          sudo apt-get install -y postgresql-${{ matrix.pg-version }}
+          sudo apt-get install -y libsnappy-dev postgresql-10 postgresql-11 postgresql-12 postgresql-13 postgresql-14
           # Setup common python dependencies
           python -m pip install --upgrade pip
           pip install -r requirements.txt

--- a/test/test_basebackup.py
+++ b/test/test_basebackup.py
@@ -428,7 +428,7 @@ LABEL: pg_basebackup base backup
     def test_basebackups_pipe(self, capsys, db, pghoard, tmpdir):
         self._test_basebackups(capsys, db, pghoard, tmpdir, BaseBackupMode.pipe)
 
-    def test_basebackups_tablespaces(self, capsys, db, pghoard, tmpdir):
+    def test_basebackups_tablespaces(self, capsys, db, pghoard, tmpdir, pg_version: str):
         # Create a test tablespace for this instance, but make sure we drop it at the end of the test as the
         # database we use is shared by all test cases, and tablespaces are a global concept so the test
         # tablespace could interfere with other tests
@@ -561,7 +561,7 @@ LABEL: pg_basebackup base backup
                 fp.seek(0)
                 fp.write(rconf)
 
-            r_db = PGTester(backup_out)
+            r_db = PGTester(pgdata=backup_out, pg_version=pg_version)
             r_db.user = dict(db.user, host=backup_out)
             r_db.run_pg()
 


### PR DESCRIPTION
# About this change - What it does

This does not change much for GitHub Actions:
one dimension of the matrix is replaced by a fixture parametrization.

For local dev environment however, it makes it easier to get accurate
coverage on all version combined, without a manual merge step and
without having to think about `PG_VERSION` environment variable.

The `PG_VERSION` variable still exists and can be used to reduce the
number of tested versions, either a single version of multiple versions
separated by a comma.

Tests that don't depend on a running PostgreSQL are now run less
often since they don't depend on the parametrized fixture.

# Why this way

Easier coverage feedback for local development.