### PR TITLE
tests: increase timeout when waiting for more xlog

### DIFF
--- a/test/util.py
+++ b/test/util.py
@@ -22,7 +22,7 @@ def wait_for_xlog(pghoard: PGHoardForTest, count: int):
             if xlogs >= count:
                 break
 
-        if time.monotonic() - start > 15:
+        if time.monotonic() - start > count * 10:
             assert False, "Expected at least {} xlog uploads, got {}".format(count, xlogs)
 
         time.sleep(0.1)


### PR DESCRIPTION
# About this change - What it does

Make the waiting time for xlog during tests proportional to the number of xlog.

# Why this way

`test_pause_on_disk_full` was waiting for more xlog than other tests and would timeout while waiting despite having done what the test expected (pause/resume).
