### PR TITLE
Fix CI pipeline - check major versions only for commands

### DIFF
--- a/test/base.py
+++ b/test/base.py
@@ -112,6 +112,7 @@ class PGHoardTestCase:
             assert ver is not None
             if version is None:
                 version = ver
-            assert version == ver
+            # Major version should match, some packages are shipped with different minor versions of binaries
+            assert version.split(".")[0] == ver.split(".")[0]
             assert os.path.dirname(command_path) == bindir
         return version


### PR DESCRIPTION
# About this change - What it does
Fixes the CI pipeline

# Why this way
In the tests we check the full versions of the PG binaries used, some packages are shipped with different minor versions of binaries (not necessarily the latest), so we should check major version only, they should be compatible.
