### PR TITLE
Ensure progress metric is updated frequently during basebackup

### DIFF
--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -718,11 +718,11 @@ class PGBaseBackup(PGHoardThread):
                     # and this assumption greatly simplifies the logic.
                     task_to_wait = pending_compress_and_encrypt_tasks.pop(0)
                     chunk_files.append(task_to_wait.result())
-                    self.metrics.gauge(
-                        "pghoard.basebackup_estimated_progress",
-                        float(len(chunk_files) * 100 / len(chunks)),
-                        tags={"site": self.site}
-                    )
+                self.metrics.gauge(
+                    "pghoard.basebackup_estimated_progress",
+                    float(len(chunk_files) * 100 / len(chunks)),
+                    tags={"site": self.site}
+                )
                 if self.chunks_on_disk < max_chunks_on_disk:
                     chunk_id = i + 1
                     task = tpe.submit(


### PR DESCRIPTION
The `pghoard.basebackup_estimated_progress` was added earlier this year, but often does not fire until the basebackup is already 100% complete.

This commit increases the frequency at which the metric is emitted.