### PR TITLE
ci: add code coverage graph

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
+comment:
+  layout: "reach, diff, flags, files"
 coverage:
   status:
     project:


### PR DESCRIPTION
Add the [reach graph](https://docs.codecov.com/docs/graphs#coverage-reach) to codecov comment.

