### PR TITLE
Backport of "Ensure progress metric is updated frequently during basebackup"

### DIFF
--- a/pghoard/basebackup.py
+++ b/pghoard/basebackup.py
@@ -671,7 +671,11 @@ class PGBaseBackup(Thread):
                     # and this assumption greatly simplifies the logic.
                     task_to_wait = pending_compress_and_encrypt_tasks.pop(0)
                     chunk_files.append(task_to_wait.result())
-
+                self.metrics.gauge(
+                    "pghoard.basebackup_estimated_progress",
+                    float(len(chunk_files) * 100 / len(chunks)),
+                    tags={"site": self.site}
+                )
                 if self.chunks_on_disk < max_chunks_on_disk:
                     chunk_id = i + 1
                     task = tpe.submit(
@@ -693,6 +697,13 @@ class PGBaseBackup(Thread):
                         self.chunks_on_disk -= 1
             for task in pending_compress_and_encrypt_tasks:
                 chunk_files.append(task.result())
+                self.metrics.gauge(
+                    "pghoard.basebackup_estimated_progress",
+                    float(len(chunk_files) * 100 / len(chunks)),
+                    tags={"site": self.site}
+                )
+
+        self.metrics.gauge("pghoard.basebackup_estimated_progress", float(100), tags={"site": self.site})
 
         while len(upload_results) < len(chunk_files):
             self.wait_for_chunk_transfer_to_complete(len(chunks), upload_results, chunk_callback_queue, start_time)


### PR DESCRIPTION
Equivalent to https://github.com/aiven/pghoard/pull/540, applied to the most recently tagged release.

Without this, the pghoard basebackup progress is not emitted frequently enough to reliably incorporate into prometheus metrics.
With this PR, we see progress each time a chunk is processed:
![image](https://user-images.githubusercontent.com/236562/177898656-c80bc77e-1263-4cff-8f30-48f31b62299a.png)
