### PR TITLE
make sure that basebackup-mode metadata is set for all base backups

### DIFF
--- a/pghoard/basebackup/base.py
+++ b/pghoard/basebackup/base.py
@@ -311,6 +311,7 @@ class PGBaseBackup(PGHoardThread):
             "original-file-size": original_input_size,
             "pg-version": self.pg_version_server,
             "active-backup-mode": self.site_config["active_backup_mode"],
+            "basebackup-mode": self.site_config["basebackup_mode"],
         })
         metadata.update(self.metadata)
 
@@ -383,6 +384,7 @@ class PGBaseBackup(PGHoardThread):
                     "start-time": start_time,
                     "start-wal-segment": start_wal_segment,
                     "active-backup-mode": self.site_config["active_backup_mode"],
+                    "basebackup-mode": self.site_config["basebackup_mode"],
                 }
             )
         )
@@ -769,6 +771,7 @@ class PGBaseBackup(PGHoardThread):
                 "end-wal-segment": backup_end_wal_segment,
                 "pg-version": self.pg_version_server,
                 "active-backup-mode": self.site_config["active_backup_mode"],
+                "basebackup-mode": self.site_config["basebackup_mode"],
                 "start-time": backup_start_time,
                 "start-wal-segment": backup_start_wal_segment,
                 "total-size-plain": total_size_plain,

--- a/test/basebackup/test_basebackup.py
+++ b/test/basebackup/test_basebackup.py
@@ -285,6 +285,7 @@ LABEL: pg_basebackup base backup
                 assert dateutil.parser.parse(backup["metadata"]["end-time"]).tzinfo  # pylint: disable=no-member
 
             assert backups[0]["metadata"]["active-backup-mode"] == active_backup_mode
+            assert backups[0]["metadata"]["basebackup-mode"] == mode
 
     def _test_restore_basebackup(self, db, pghoard, tmpdir, active_backup_mode="archive_command"):
         backup_out = tmpdir.join("test-restore").strpath


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
Adds the basebackup-mode metadata to all base backup metadata

<!-- Provide a small sentence that summarizes the change. -->
Adds the basebackup-mode metadata value to all base backup metadata
<!-- Provide the issue number below if it exists. -->
Resolves: #543

# Why this way
It was simple
<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

