### PR TITLE
teach rohmu to notifiy when it writes anything [AD-756]

### DIFF
--- a/pghoard/rohmu/__init__.py
+++ b/pghoard/rohmu/__init__.py
@@ -37,4 +37,7 @@ def get_transfer(storage_config):
     storage_class = get_class_for_transfer(storage_config)
     storage_config = storage_config.copy()
     storage_config.pop("storage_type")
-    return storage_class(**storage_config)
+    notification_url = storage_config.pop("notification_url", None)
+    ret = storage_class(**storage_config)
+    ret.update_notification_url(notification_url)
+    return ret

--- a/pghoard/rohmu/object_storage/azure.py
+++ b/pghoard/rohmu/object_storage/azure.py
@@ -48,11 +48,9 @@ logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(l
 
 
 class AzureTransfer(BaseTransfer):
-    def __init__(
-        self, account_name, account_key, bucket_name, prefix=None, azure_cloud=None, proxy_info=None, notification_url=None
-    ):
+    def __init__(self, account_name, account_key, bucket_name, prefix=None, azure_cloud=None, proxy_info=None):
         prefix = "{}".format(prefix.lstrip("/") if prefix else "")
-        super().__init__(prefix=prefix, notification_url=notification_url)
+        super().__init__(prefix=prefix)
         self.account_name = account_name
         self.account_key = account_key
         self.container_name = bucket_name

--- a/pghoard/rohmu/object_storage/azure.py
+++ b/pghoard/rohmu/object_storage/azure.py
@@ -47,9 +47,11 @@ logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(l
 
 
 class AzureTransfer(BaseTransfer):
-    def __init__(self, account_name, account_key, bucket_name, prefix=None, azure_cloud=None, proxy_info=None):
+    def __init__(
+        self, account_name, account_key, bucket_name, prefix=None, azure_cloud=None, proxy_info=None, notification_url=None
+    ):
         prefix = "{}".format(prefix.lstrip("/") if prefix else "")
-        super().__init__(prefix=prefix)
+        super().__init__(prefix=prefix, notification_url=notification_url)
         self.account_name = account_name
         self.account_key = account_key
         self.container_name = bucket_name

--- a/pghoard/rohmu/object_storage/azure.py
+++ b/pghoard/rohmu/object_storage/azure.py
@@ -5,6 +5,7 @@ Copyright (c) 2016 Ohmu Ltd
 See LICENSE for details
 """
 import logging
+import os
 import time
 from io import BytesIO
 
@@ -186,6 +187,7 @@ class AzureTransfer(BaseTransfer):
                 )
 
     def delete_key(self, key):
+        plain_key = key
         key = self.format_key_for_backend(key, remove_slash_prefix=True)
         self.log.debug("Deleting key: %r", key)
         try:
@@ -193,6 +195,7 @@ class AzureTransfer(BaseTransfer):
             return blob_client.delete_blob()
         except azure.core.exceptions.ResourceNotFoundError as ex:  # pylint: disable=no-member
             raise FileNotFoundFromStorageError(key) from ex
+        self.notify_delete(plain_key)
 
     def get_contents_to_file(self, key, filepath_to_store_to, *, progress_callback=None):
         key = self.format_key_for_backend(key, remove_slash_prefix=True)
@@ -283,6 +286,7 @@ class AzureTransfer(BaseTransfer):
     def store_file_from_memory(self, key, memstring, metadata=None, cache_control=None, mimetype=None):
         if cache_control is not None:
             raise NotImplementedError("AzureTransfer: cache_control support not implemented")
+        plain_key = key
         key = self.format_key_for_backend(key, remove_slash_prefix=True)
         content_settings = None
         if mimetype:
@@ -295,10 +299,12 @@ class AzureTransfer(BaseTransfer):
             metadata=self.sanitize_metadata(metadata, replace_hyphen_with="_"),
             overwrite=True
         )
+        self.notify_write(key=plain_key, size=len(bytes(memstring)))
 
     def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
         if cache_control is not None:
             raise NotImplementedError("AzureTransfer: cache_control support not implemented")
+        plain_key = key
         key = self.format_key_for_backend(key, remove_slash_prefix=True)
         content_settings = None
         if mimetype:
@@ -312,10 +318,13 @@ class AzureTransfer(BaseTransfer):
                 metadata=self.sanitize_metadata(metadata, replace_hyphen_with="_"),
                 overwrite=True
             )
+        size = os.path.getsize(filepath)
+        self.notify_write(key=plain_key, size=size)
 
     def store_file_object(self, key, fd, *, cache_control=None, metadata=None, mimetype=None, upload_progress_fn=None):
         if cache_control is not None:
             raise NotImplementedError("AzureTransfer: cache_control support not implemented")
+        plain_key = key
         key = self.format_key_for_backend(key, remove_slash_prefix=True)
         content_settings = None
         if mimetype:
@@ -342,6 +351,7 @@ class AzureTransfer(BaseTransfer):
                 raw_response_hook=progress_callback,
                 overwrite=True
             )
+            self.notify_write(key=plain_key, size=self.get_file_size(key))
         finally:
             if not seekable:
                 if original_tell is not None:

--- a/pghoard/rohmu/object_storage/base.py
+++ b/pghoard/rohmu/object_storage/base.py
@@ -7,7 +7,6 @@ See LICENSE for details
 import logging
 import platform
 from collections import namedtuple
-from dataclasses import dataclass
 
 import requests
 
@@ -33,9 +32,9 @@ def get_requests_session() -> requests.Session:
 
 
 class BaseTransfer:
-    def __init__(self, prefix, notification_url=None):
+    def __init__(self, prefix):
         self.log = logging.getLogger(self.__class__.__name__)
-        self.notification_url = notification_url
+        self.notification_url = None
         if not prefix:
             prefix = ""
         elif prefix[-1] != "/":
@@ -137,6 +136,10 @@ class BaseTransfer:
 
     def store_file_object(self, key, fd, *, cache_control=None, metadata=None, mimetype=None, upload_progress_fn=None):
         raise NotImplementedError
+
+    def update_notification_url(self, url: str) -> None:
+        """Allow changing the notificaiton url without having to recreate the object"""
+        self.notification_url = url
 
     def _notify(self, operation):
         """Inform notification_url about operation"""

--- a/pghoard/rohmu/object_storage/base.py
+++ b/pghoard/rohmu/object_storage/base.py
@@ -7,6 +7,9 @@ See LICENSE for details
 import logging
 import platform
 from collections import namedtuple
+from dataclasses import dataclass
+
+import requests
 
 from ..errors import StorageError
 
@@ -16,9 +19,23 @@ KEY_TYPE_PREFIX = "prefix"
 IterKeyItem = namedtuple("IterKeyItem", ["type", "value"])
 
 
+def get_requests_session() -> requests.Session:
+    retry = requests.adapters.Retry(
+        total=3,
+        backoff_factor=0.5,  # sleeps: 0, 1s, 2s, 4s... by default, backoff was disabled!
+        status_forcelist=[429, 500, 502, 503, 504],
+        method_whitelist={"POST"},  # gets replaced with allowed_methods in new versions
+    )
+    adapter = requests.adapters.HTTPAdapter(max_retries=retry)
+    request_session = requests.Session()
+    request_session.mount("http://", adapter)
+    return request_session
+
+
 class BaseTransfer:
-    def __init__(self, prefix):
+    def __init__(self, prefix, notification_url=None):
         self.log = logging.getLogger(self.__class__.__name__)
+        self.notification_url = notification_url
         if not prefix:
             prefix = ""
         elif prefix[-1] != "/":
@@ -120,6 +137,26 @@ class BaseTransfer:
 
     def store_file_object(self, key, fd, *, cache_control=None, metadata=None, mimetype=None, upload_progress_fn=None):
         raise NotImplementedError
+
+    def _notify(self, operation):
+        """Inform notification_url about operation"""
+        if self.notification_url:
+            try:
+                with get_requests_session() as session:
+                    session.post(f"{self.notification_url}", json=operation)
+            except requests.RequestException as ex:
+                self.log.warning("Could not inform robjecter about %r, because %s", operation, ex)
+                # TODO: store the failure information and retry on next chance, something like this
+                # if robjecter.retry_later_on_failure
+                #   self.reconvey_operations.append(operation)
+                # order of operations might be important here, also if transfer object gets dropped then these will be lost
+                # so provde a method to retry these explicity
+
+    def notify_write(self, key, size):
+        self._notify({"key": key, "size_bytes": size, "op": "UPLOAD"})
+
+    def notify_delete(self, key):
+        self._notify({"key": key, "op": "DELETE"})
 
 
 def get_total_memory():

--- a/pghoard/rohmu/object_storage/google.py
+++ b/pghoard/rohmu/object_storage/google.py
@@ -96,8 +96,17 @@ def base64_to_hex(b64val):
 
 
 class GoogleTransfer(BaseTransfer):
-    def __init__(self, project_id, bucket_name, credential_file=None, credentials=None, prefix=None, proxy_info=None):
-        super().__init__(prefix=prefix)
+    def __init__(
+        self,
+        project_id,
+        bucket_name,
+        credential_file=None,
+        credentials=None,
+        prefix=None,
+        proxy_info=None,
+        notification_url=None
+    ):
+        super().__init__(prefix=prefix, notification_url=notification_url)
         self.project_id = project_id
         self.proxy_info = proxy_info
         self.google_creds = get_credentials(credential_file=credential_file, credentials=credentials)

--- a/pghoard/rohmu/object_storage/google.py
+++ b/pghoard/rohmu/object_storage/google.py
@@ -96,17 +96,8 @@ def base64_to_hex(b64val):
 
 
 class GoogleTransfer(BaseTransfer):
-    def __init__(
-        self,
-        project_id,
-        bucket_name,
-        credential_file=None,
-        credentials=None,
-        prefix=None,
-        proxy_info=None,
-        notification_url=None
-    ):
-        super().__init__(prefix=prefix, notification_url=notification_url)
+    def __init__(self, project_id, bucket_name, credential_file=None, credentials=None, prefix=None, proxy_info=None):
+        super().__init__(prefix=prefix)
         self.project_id = project_id
         self.proxy_info = proxy_info
         self.google_creds = get_credentials(credential_file=credential_file, credentials=credentials)

--- a/pghoard/rohmu/object_storage/local.py
+++ b/pghoard/rohmu/object_storage/local.py
@@ -20,9 +20,9 @@ CHUNK_SIZE = 1024 * 1024
 
 
 class LocalTransfer(BaseTransfer):
-    def __init__(self, directory, prefix=None):
+    def __init__(self, directory, prefix=None, notification_url=None):
         prefix = os.path.join(directory, (prefix or "").strip("/"))
-        super().__init__(prefix=prefix)
+        super().__init__(prefix=prefix, notification_url=notification_url)
         self.log.debug("LocalTransfer initialized")
 
     def copy_file(self, *, source_key, destination_key, metadata=None, **_kwargs):

--- a/pghoard/rohmu/object_storage/local.py
+++ b/pghoard/rohmu/object_storage/local.py
@@ -20,9 +20,9 @@ CHUNK_SIZE = 1024 * 1024
 
 
 class LocalTransfer(BaseTransfer):
-    def __init__(self, directory, prefix=None, notification_url=None):
+    def __init__(self, directory, prefix=None):
         prefix = os.path.join(directory, (prefix or "").strip("/"))
-        super().__init__(prefix=prefix, notification_url=notification_url)
+        super().__init__(prefix=prefix)
         self.log.debug("LocalTransfer initialized")
 
     def copy_file(self, *, source_key, destination_key, metadata=None, **_kwargs):

--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -142,10 +142,12 @@ class S3Transfer(BaseTransfer):
         return response["Metadata"]
 
     def delete_key(self, key):
+        plain_key = key
         key = self.format_key_for_backend(key, remove_slash_prefix=True)
         self.log.debug("Deleting key: %r", key)
         self._metadata_for_key(key)  # check that key exists
         self.s3_client.delete_object(Bucket=self.bucket_name, Key=key)
+        self.notify_delete(plain_key)
 
     def delete_tree(self, key):
         key = self.format_key_for_backend(key, remove_slash_prefix=True, trailing_slash=True)
@@ -255,6 +257,7 @@ class S3Transfer(BaseTransfer):
                 raise StorageError("File size lookup failed for {}".format(key)) from ex
 
     def store_file_from_memory(self, key, memstring, metadata=None, cache_control=None, mimetype=None):
+        plain_key = key
         key = self.format_key_for_backend(key, remove_slash_prefix=True)
         args = {
             "Bucket": self.bucket_name,
@@ -270,8 +273,10 @@ class S3Transfer(BaseTransfer):
         if mimetype is not None:
             args["ContentType"] = mimetype
         self.s3_client.put_object(**args)
+        self.notify_write(key=plain_key, size=len(bytes(memstring)))
 
     def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
+        plain_key = key
         size = os.path.getsize(filepath)
         if not multipart or size <= self.multipart_chunk_size:
             with open(filepath, "rb") as fh:
@@ -283,6 +288,7 @@ class S3Transfer(BaseTransfer):
             self.multipart_upload_file_object(
                 cache_control=cache_control, fp=fp, key=key, metadata=metadata, mimetype=mimetype, size=size
             )
+        self.notify_write(key=plain_key, size=size)
 
     def multipart_upload_file_object(self, *, cache_control, fp, key, metadata, mimetype, progress_fn=None, size=None):
         key = self.format_key_for_backend(key, remove_slash_prefix=True)
@@ -396,6 +402,7 @@ class S3Transfer(BaseTransfer):
             mimetype=mimetype,
             progress_fn=upload_progress_fn
         )
+        self.notify_write(key=key, size=self.get_file_size(key))
 
     def check_or_create_bucket(self):
         create_bucket = False

--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -45,9 +45,10 @@ class S3Transfer(BaseTransfer):
         is_verify_tls=False,
         segment_size=MULTIPART_CHUNK_SIZE,
         encrypted=False,
-        proxy_info=None
+        proxy_info=None,
+        notification_url=None,
     ):
-        super().__init__(prefix=prefix)
+        super().__init__(prefix=prefix, notification_url=notification_url)
         botocore_session = botocore.session.get_session()
         self.bucket_name = bucket_name
         self.location = ""

--- a/pghoard/rohmu/object_storage/s3.py
+++ b/pghoard/rohmu/object_storage/s3.py
@@ -45,10 +45,9 @@ class S3Transfer(BaseTransfer):
         is_verify_tls=False,
         segment_size=MULTIPART_CHUNK_SIZE,
         encrypted=False,
-        proxy_info=None,
-        notification_url=None,
+        proxy_info=None
     ):
-        super().__init__(prefix=prefix, notification_url=notification_url)
+        super().__init__(prefix=prefix)
         botocore_session = botocore.session.get_session()
         self.bucket_name = bucket_name
         self.location = ""

--- a/pghoard/rohmu/object_storage/swift.py
+++ b/pghoard/rohmu/object_storage/swift.py
@@ -62,10 +62,11 @@ class SwiftTransfer(BaseTransfer):
         project_domain_id=None,
         project_domain_name=None,
         service_type=None,
-        endpoint_type=None
+        endpoint_type=None,
+        notification_url=None,
     ):
         prefix = prefix.lstrip("/") if prefix else ""
-        super().__init__(prefix=prefix)
+        super().__init__(prefix=prefix, notification_url=notification_url)
         self.container_name = container_name
 
         if auth_version == "3.0":

--- a/pghoard/rohmu/object_storage/swift.py
+++ b/pghoard/rohmu/object_storage/swift.py
@@ -62,11 +62,10 @@ class SwiftTransfer(BaseTransfer):
         project_domain_id=None,
         project_domain_name=None,
         service_type=None,
-        endpoint_type=None,
-        notification_url=None,
+        endpoint_type=None
     ):
         prefix = prefix.lstrip("/") if prefix else ""
-        super().__init__(prefix=prefix, notification_url=notification_url)
+        super().__init__(prefix=prefix)
         self.container_name = container_name
 
         if auth_version == "3.0":

--- a/pghoard/rohmu/object_storage/swift.py
+++ b/pghoard/rohmu/object_storage/swift.py
@@ -175,6 +175,7 @@ class SwiftTransfer(BaseTransfer):
                     self._delete_object_plain(item["name"])
 
     def delete_key(self, key):
+        plain_key = key
         key = self.format_key_for_backend(key)
         self.log.debug("Deleting key: %r", key)
         try:
@@ -187,6 +188,7 @@ class SwiftTransfer(BaseTransfer):
             self._delete_object_segments(key, headers["x-object-manifest"])
         else:
             self._delete_object_plain(key)
+        self.notify_delete(plain_key)
 
     def get_contents_to_file(self, key, filepath_to_store_to, *, progress_callback=None):
         temp_filepath = "{}~".format(filepath_to_store_to)
@@ -244,11 +246,13 @@ class SwiftTransfer(BaseTransfer):
         if cache_control is not None:
             raise NotImplementedError("SwiftTransfer: cache_control support not implemented")
 
+        plain_key = key
         key = self.format_key_for_backend(key)
         metadata_to_send = self._metadata_to_headers(self.sanitize_metadata(metadata))
         self.conn.put_object(
             self.container_name, key, contents=bytes(memstring), content_type=mimetype, headers=metadata_to_send
         )
+        self.notify_write(key=plain_key, size=len(bytes(memstring)))
 
     def store_file_from_disk(self, key, filepath, metadata=None, multipart=None, cache_control=None, mimetype=None):
         if cache_control is not None:
@@ -261,6 +265,7 @@ class SwiftTransfer(BaseTransfer):
             # chunks.
             with suppress(FileNotFoundFromStorageError):
                 self.delete_key(key)
+        plain_key = key
         key = self.format_key_for_backend(key)
         headers = self._metadata_to_headers(self.sanitize_metadata(metadata))
         obsz = os.path.getsize(filepath)
@@ -289,6 +294,8 @@ class SwiftTransfer(BaseTransfer):
             self.log.info("Uploaded %r segments of %r to %r", segment_no, key, segment_path)
             headers["x-object-manifest"] = "{}/{}".format(self.container_name, segment_path.lstrip("/"))
             self.conn.put_object(self.container_name, key, contents="", headers=headers, content_length=0)
+        size = os.path.getsize(filepath)
+        self.notify_write(key=plain_key, size=size)
 
     def get_or_create_container(self, container_name):
         start_time = time.monotonic()


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
This allows robjecter to be informed everyime pghoard (rohmu) writes anything. This can be controlled with the presence of extra config passed to the constructors of each object storage driver.

The `plain_key` is needed as robjecter itself uses rohmu so the `prefix` gets prefixed twice.
size is not strictly needed but helps make robjecter's work easier. And here size is easily avaialble statically or dynamically (in case of multipart-uploads). In case of multipart uploads the size could calculated using the callback mechanisms locally however each driver reports callback in a different manner and in some cases the callback might not be called if a multipart upload was not necessary.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

 [AD-756]


[AD-756]: https://aiven.atlassian.net/browse/AD-756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ