### PR TITLE
Add more retries in case of download failure

### DIFF
--- a/test/test_restore.py
+++ b/test/test_restore.py
@@ -21,7 +21,8 @@ import pytest
 
 from pghoard.common import write_json_file
 from pghoard.restore import (
-    BasebackupFetcher, ChunkFetcher, FileDataInfo, FileInfoType, FilePathInfo, Restore, RestoreError, create_recovery_conf
+    MAX_RETRIES, BasebackupFetcher, ChunkFetcher, FileDataInfo, FileInfoType, FilePathInfo, Restore, RestoreError,
+    create_recovery_conf
 )
 
 from .base import PGHoardTestCase
@@ -360,7 +361,7 @@ class TestBasebackupFetcher(unittest.TestCase):
 
         fetcher.max_stale_seconds = 2
         with patch("pghoard.restore.ChunkFetcher", new=FailingChunkFetcher):
-            if max_fails <= 2:
+            if max_fails < MAX_RETRIES:
                 fetcher.fetch_all()
                 self.check_sha256(
                     os.path.join(restore_dir, "pg_notify", "0000"),


### PR DESCRIPTION
In some rare cases 3 retries isn't enough but 6 is. This should really be made configurable but creating this pr as a quick fix in case nobody else feels like creating a better one.