### PR TITLE
Rommel layco receivelog respects sighup

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -868,9 +868,17 @@ class PGHoard:
                 raise
             raise InvalidConfigurationError(self.config_path)
 
+        self.config = new_config
+        self.synchronize_new_config()
+
+    def synchronize_new_config(self) -> None:
+        """
+        Ensure that all sub-components' references to the config
+        are refreshed, so that any changes are visible.
+        """
+
         # clear this objects site transfer storage config
         self.site_transfers = {}
-        self.config = new_config
 
         if self.config.get("syslog") and not self.syslog_handler:
             self.syslog_handler = logutil.set_syslog_handler(
@@ -894,10 +902,14 @@ class PGHoard:
 
         # need to refresh the web server config too
         if hasattr(self, "webserver") and hasattr(self.webserver, "server"):
-            self.webserver.server.config = new_config
+            self.webserver.server.config = self.config
 
         for thread in self._get_all_threads():
-            thread.config = new_config
+            if hasattr(thread, "new_config"):
+                thread.new_config.put(self.config)
+            else:
+                thread.config = self.config
+
             thread.site_transfers = {}
 
         self.log.debug("Loaded config: %r from: %r", self.config, self.config_path)

--- a/pghoard/receivexlog.py
+++ b/pghoard/receivexlog.py
@@ -12,6 +12,7 @@ import select
 import signal
 import subprocess
 import time
+from queue import Empty, Queue
 
 from .common import (PGHoardThread, set_subprocess_stdout_and_stderr_nonblocking, terminate_subprocess)
 
@@ -19,14 +20,11 @@ from .common import (PGHoardThread, set_subprocess_stdout_and_stderr_nonblocking
 class PGReceiveXLog(PGHoardThread):
     def __init__(self, config, connection_string, wal_location, site, slot, pg_version_server):
         super().__init__()
-        pg_receivexlog_config = config["backup_sites"][site]["pg_receivexlog"]
         self.log = logging.getLogger("PGReceiveXLog")
+        self.new_config = Queue()
         self.config = config
         self.connection_string = connection_string
-        self.disk_space_check_interval = pg_receivexlog_config["disk_space_check_interval"]
         self.last_disk_space_check = time.monotonic()
-        self.min_disk_space = pg_receivexlog_config.get("min_disk_free_bytes")
-        self.resume_multiplier = pg_receivexlog_config["resume_multiplier"]
         self.wal_location = wal_location
         self.site = site
         self.slot = slot
@@ -36,6 +34,22 @@ class PGReceiveXLog(PGHoardThread):
         self.running = False
         self.latest_activity = datetime.datetime.utcnow()
         self.log.debug("Initialized PGReceiveXLog")
+
+    @property
+    def pg_receivexlog_config(self):
+        return self.config["backup_sites"][self.site]["pg_receivexlog"]
+
+    @property
+    def disk_space_check_interval(self):
+        return self.pg_receivexlog_config["disk_space_check_interval"]
+
+    @property
+    def min_disk_space(self):
+        return self.pg_receivexlog_config.get("min_disk_free_bytes")
+
+    @property
+    def resume_multiplier(self):
+        return self.pg_receivexlog_config["resume_multiplier"]
 
     def run_safe(self):
         self.running = True
@@ -61,6 +75,13 @@ class PGReceiveXLog(PGHoardThread):
         self.log.info("Started: %r, running as PID: %r", command, self.pid)
         while self.running:
             rlist, _, _ = select.select([proc.stdout, proc.stderr], [], [], min(1.0, self.disk_space_check_interval))
+            try:
+                self.config = self.new_config.get(block=False)
+                self.log.info("Loaded new configuration")
+                self.log.info(str(self.pg_receivexlog_config))
+                continue
+            except Empty:
+                pass
             for fd in rlist:
                 content = fd.read()
                 if content:

--- a/test/util.py
+++ b/test/util.py
@@ -11,7 +11,11 @@ from pghoard.common import json_encode
 from .conftest import PGHoardForTest
 
 
-def wait_for_xlog(pghoard: PGHoardForTest, count: int):
+class Timeout(Exception):
+    pass
+
+
+def wait_for_xlog(pghoard: PGHoardForTest, count: int, *, timeout_seconds: int = 15):
     start = time.monotonic()
     while True:
         xlogs = None
@@ -22,8 +26,8 @@ def wait_for_xlog(pghoard: PGHoardForTest, count: int):
             if xlogs >= count:
                 break
 
-        if time.monotonic() - start > 15:
-            assert False, "Expected at least {} xlog uploads, got {}".format(count, xlogs)
+        if time.monotonic() - start > timeout_seconds:
+            raise Timeout("Expected at least {} xlog uploads, got {}".format(count, xlogs))
 
         time.sleep(0.1)
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
This modifies the receivexlog to use the updated configuration settings following a SIGHUP



<!-- Provide the issue number below if it exists. -->
This is a continuation of the work done in https://github.com/aiven/pghoard/pull/530

# Why this way

When SIGHUP is issued, self.config is refreshed in all threads, but without this change, the new values are disregarded. This change ensures the updated config object is always used.

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

