### PR TITLE
Resolve two small mypy errors

### DIFF
--- a/pghoard/basebackup/chunks.py
+++ b/pghoard/basebackup/chunks.py
@@ -137,7 +137,7 @@ class ChunkUploader:
         files_to_backup,
         callback_queue: CallbackQueue,
         file_type: FileType = FileType.Basebackup_chunk,
-        extra_metadata: Dict[str, Any] = None,
+        extra_metadata: Optional[Dict[str, Any]] = None,
         delta_stats: Optional[DeltaStats] = None
     ) -> Tuple[str, int, int]:
         start_time = time.monotonic()

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -264,9 +264,6 @@ class PGHoard:
     def start_walreceiver(self, site, chosen_backup_node, last_flushed_lsn):
         connection_string, slot = replication_connection_string_and_slot_using_pgpass(chosen_backup_node)
         pg_version_server = self.check_pg_server_version(connection_string, site)
-        if not WALReceiver:
-            self.log.error("Could not import WALReceiver, incorrect psycopg2 version?")
-            return
 
         thread = WALReceiver(
             config=self.config,


### PR DESCRIPTION
The new mypy version causes the mypy checker to detect two previously-undetected errors.