### PR TITLE
ipv6 webserver support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,10 @@ Vagrant.configure("2") do |config|
     $script = <<-SCRIPT
         export DEBIAN_FRONTEND="noninteractive"
 
+        # do not disable ipv6, the base vagrant image has disabled this
+        sysctl net.ipv6.conf.all.disable_ipv6=0
+        sed -i '/net.ipv6.conf.all.disable_ipv6/d' /etc/sysctl.conf
+
         # optionally enable use of ng apt cacher on the host
         export NG_PROXY_URL="#{ENV['NG_PROXY_URL']}"
         if [ "$NG_PROXY_URL" != "" ]; then

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -256,6 +256,26 @@ def fixture_pghoard(db, tmpdir, request):
     yield from pghoard_base(db, tmpdir, request)
 
 
+@pytest.fixture(name="pghoard_ipv4_hostname")
+def fixture_pghoard_ipv4_hostname(db, tmpdir, request):
+    yield from pghoard_base(db, tmpdir, request, listen_http_address="localhost")
+
+
+@pytest.fixture(name="pghoard_ipv6_wildcard")
+def fixture_pghoard_ipv6_wildcard(db, tmpdir, request):
+    yield from pghoard_base(db, tmpdir, request, listen_http_address="::")
+
+
+@pytest.fixture(name="pghoard_empty_listen_address")
+def fixture_pghoard_empty_listen_address(db, tmpdir, request):
+    yield from pghoard_base(db, tmpdir, request, listen_http_address="")
+
+
+@pytest.fixture(name="pghoard_ipv6_loopback")
+def fixture_pghoard_ipv6_loopback(db, tmpdir, request):
+    yield from pghoard_base(db, tmpdir, request, listen_http_address="::1")
+
+
 @pytest.fixture(name="pghoard_walreceiver")
 def fixture_pghoard_walreceiver(db, tmpdir, request):
     # Initialize with only one transfer agent, as we want a reliable
@@ -320,7 +340,8 @@ def pghoard_base(
     pg_receivexlog_config=None,
     active_backup_mode="pg_receivexlog",
     slot_name=None,
-    compression_count=None
+    compression_count=None,
+    listen_http_address="127.0.0.1"
 ):
     test_site = request.function.__name__
 
@@ -353,7 +374,7 @@ def pghoard_base(
         "compression": {
             "algorithm": compression,
         },
-        "http_address": "127.0.0.1",
+        "http_address": listen_http_address,
         "http_port": random.randint(1024, 32000),
         "json_state_file_path": tmpdir.join("pghoard_state.json").strpath,
         "maintenance_mode_file": tmpdir.join("maintenance_mode_file").strpath,

--- a/test/test_webserver_ipv6.py
+++ b/test/test_webserver_ipv6.py
@@ -1,0 +1,81 @@
+"""
+pghoard
+
+Copyright (c) 2015 Ohmu Ltd
+See LICENSE for details
+"""
+import json
+from http.client import HTTPConnection
+
+from pytest import raises
+
+
+class TestIPV6WebServer:
+    # verify that existing behaviour of listening on all IPV4 addresses if an empty http_address is
+    # specified
+    def test_ipv4_endpoint_with_empty_listen_address(self, pghoard_empty_listen_address):
+        pghoard_empty_listen_address.write_backup_state_to_json_file()
+        conn = HTTPConnection(host="127.0.0.1", port=pghoard_empty_listen_address.config["http_port"])
+        conn.request("GET", "/status")
+        response = conn.getresponse()
+        response_parsed = json.loads(response.read().decode("utf-8"))
+        assert response.status == 200
+        assert response_parsed["startup_time"] is not None
+
+    # an empty http_address does not make pghoard listen on IPV6
+    def test_ipv6_endpoint_fails_with_empty_listen_address(self, pghoard_empty_listen_address):
+        pghoard_empty_listen_address.write_backup_state_to_json_file()
+        conn = HTTPConnection(host="::1", port=pghoard_empty_listen_address.config["http_port"])
+        with raises(ConnectionRefusedError):
+            conn.request("GET", "/status")
+
+    def test_ipv4_endpoint_with_ipv4_hostname_listen_address(self, pghoard_ipv4_hostname):
+        pghoard_ipv4_hostname.write_backup_state_to_json_file()
+        conn = HTTPConnection(host="127.0.0.1", port=pghoard_ipv4_hostname.config["http_port"])
+        conn.request("GET", "/status")
+        response = conn.getresponse()
+        response_parsed = json.loads(response.read().decode("utf-8"))
+        assert response.status == 200
+        assert response_parsed["startup_time"] is not None
+
+    # an empty http_address does not make pghoard listen on IPV6
+    def test_ipv6_endpoint_fails_with_ipv4_hostname_listen_address(self, pghoard_ipv4_hostname):
+        pghoard_ipv4_hostname.write_backup_state_to_json_file()
+        conn = HTTPConnection(host="::1", port=pghoard_ipv4_hostname.config["http_port"])
+        with raises(ConnectionRefusedError):
+            conn.request("GET", "/status")
+
+    # a IPV6 wildcard (::) supports connecting with the IPV4 lookback address (and in fact any IPV4 interface)
+    def test_ipv4_endpoint_with_wildcard_ipv6_listen_address(self, pghoard_ipv6_wildcard):
+        pghoard_ipv6_wildcard.write_backup_state_to_json_file()
+        conn = HTTPConnection(host="127.0.0.1", port=pghoard_ipv6_wildcard.config["http_port"])
+        conn.request("GET", "/status")
+        response = conn.getresponse()
+        response_parsed = json.loads(response.read().decode("utf-8"))
+        assert response.status == 200
+        assert response_parsed["startup_time"] is not None
+
+    def test_ipv6_endpoint_with_wildcard_ipv6_listen_address(self, pghoard_ipv6_wildcard):
+        pghoard_ipv6_wildcard.write_backup_state_to_json_file()
+        conn = HTTPConnection(host="::1", port=pghoard_ipv6_wildcard.config["http_port"])
+        conn.request("GET", "/status")
+        response = conn.getresponse()
+        response_parsed = json.loads(response.read().decode("utf-8"))
+        assert response.status == 200
+        assert response_parsed["startup_time"] is not None
+
+    def test_ipv6_endpoint_with_loopback_ipv6_listen_address(self, pghoard_ipv6_loopback):
+        pghoard_ipv6_loopback.write_backup_state_to_json_file()
+        conn = HTTPConnection(host="::1", port=pghoard_ipv6_loopback.config["http_port"])
+        conn.request("GET", "/status")
+        response = conn.getresponse()
+        response_parsed = json.loads(response.read().decode("utf-8"))
+        assert response.status == 200
+        assert response_parsed["startup_time"] is not None
+
+    # You cannot connect to pghoard on the IPV4 loopback if it was started with the IPV6 loopback address
+    def test_ipv4_endpoint_fails_with_loopback_ipv6_listen_address(self, pghoard_ipv6_loopback):
+        pghoard_ipv6_loopback.write_backup_state_to_json_file()
+        conn = HTTPConnection(host="127.0.0.1", port=pghoard_ipv6_loopback.config["http_port"])
+        with raises(ConnectionRefusedError):
+            conn.request("GET", "/status")


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
Allows specifying a IPV6 `http_address`.   Specifying the IPV6 `::` wildcard address will cause pghoard to listen on all IPV6 and IPV4 interfaces.   Specifying a specific IPV6 address will only listen on that IPV6 address.  Specifying the IPV4 wildcard (`0.0.0.0`) or an empty `http_address` will behave as it does now; only listening on all IPV4 interfaces.

<!-- Provide a small sentence that summarizes the change. -->

Add support for specifying a ipv6 `http_address`

<!-- Provide the issue number below if it exists. -->
Resolves: #569

# Why this way
KISS principle basically
<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

