### PR TITLE
Update Vagrantfile to remove python 3.6, add python 3.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,42 +128,42 @@ Vagrant
 =======
 
 The Vagrantfile can be used to setup a vagrant development environment.   The vagrant environment has
-python 3.6, 3.7, 3.8 and 3.9 virtual environments and installations of postgresql 9.6, 10, 11 and 12.
+python 3.7, 3.8, 3.9 and 3.10 virtual environments and installations of postgresql 10, 11 and 12, 13 and 14.
 
-By default vagrant up will start a Virtualbox environment.   The Vagrantfile will also work for libvirt, just prefix
-VAGRANT_DEFAULT_PROVIDER=libvirt to the vagrant up command.
+By default vagrant up will start a Virtualbox environment. The Vagrantfile will also work for libvirt, just prefix
+``VAGRANT_DEFAULT_PROVIDER=libvirt`` to the ``vagrant up`` command.
 
-Any combination of Python (3.6, 3.7 and 3.8) and Postgresql (9.6, 10, 11 and 12)
+Any combination of Python (3.7, 3.8, 3.9 and 3.10) and Postgresql (10, 11, 12, 13 and 14)
 
 Bring up vagrant instance and connect via ssh::
 
-vagrant up
-vagrant ssh
-vagrant@ubuntu2004:~$ cd /vagrant
+  vagrant up
+  vagrant ssh
+  vagrant@ubuntu2004:~$ cd /vagrant
 
-Test with Python 3.6 and Postgresql 9.6
+Test with Python 3.7 and Postgresql 10::
 
-vagrant@ubuntu2004:~$ source ~/venv3.6/bin/activate
-vagrant@ubuntu2004:~$ PG_VERSION=9.6 make unittest
-vagrant@ubuntu2004:~$ deactivate
+  vagrant@ubuntu2004:~$ source ~/venv3.7/bin/activate
+  vagrant@ubuntu2004:~$ PG_VERSION=10 make unittest
+  vagrant@ubuntu2004:~$ deactivate
 
-Test with Python 3.7 and Postgresql 10
+Test with Python 3.8 and Postgresql 11::
 
-vagrant@ubuntu2004:~$ source ~/venv3.7/bin/activate
-vagrant@ubuntu2004:~$ PG_VERSION=10 make unittest
-vagrant@ubuntu2004:~$ deactivate
+  vagrant@ubuntu2004:~$ source ~/venv3.8/bin/activate
+  vagrant@ubuntu2004:~$ PG_VERSION=11 make unittest
+  vagrant@ubuntu2004:~$ deactivate
 
-Test with Python 3.8 and Postgresql 11
+Test with Python 3.9 and Postgresql 12::
 
-vagrant@ubuntu2004:~$ source ~/venv3.8/bin/activate
-vagrant@ubuntu2004:~$ PG_VERSION=11 make unittest
-vagrant@ubuntu2004:~$ deactivate
+  vagrant@ubuntu2004:~$ source ~/venv3.9/bin/activate
+  vagrant@ubuntu2004:~$ PG_VERSION=12 make unittest
+  vagrant@ubuntu2004:~$ deactivate
 
-Test with Python 3.9 and Postgresql 12
+Test with Python 3.10 and Postgresql 13::
 
-vagrant@ubuntu2004:~$ source ~/venv3.9/bin/activate
-vagrant@ubuntu2004:~$ PG_VERSION=12 make unittest
-vagrant@ubuntu2004:~$ deactivate
+  vagrant@ubuntu2004:~$ source ~/venv3.10/bin/activate
+  vagrant@ubuntu2004:~$ PG_VERSION=13 make unittest
+  vagrant@ubuntu2004:~$ deactivate
 
 And so on
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,13 +27,6 @@ Vagrant.configure("2") do |config|
         sysctl net.ipv6.conf.all.disable_ipv6=0
         sed -i '/net.ipv6.conf.all.disable_ipv6/d' /etc/sysctl.conf
 
-        # optionally enable use of ng apt cacher on the host
-        export NG_PROXY_URL="#{ENV['NG_PROXY_URL']}"
-        if [ "$NG_PROXY_URL" != "" ]; then
-            echo "Enabling Apt Proxy ($NG_PROXY_URL) ..."
-            echo 'Acquire::http { Proxy "$NG_PROXY_URL"; };' > /etc/apt/apt.conf.d/02proxy
-        fi
-
         echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list
         wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
         add-apt-repository -y ppa:deadsnakes/ppa
@@ -45,7 +38,7 @@ Vagrant.configure("2") do |config|
         sed -i "s/^#start_conf.*/start_conf='manual'/g" /etc/postgresql-common/createcluster.conf
         sed -i "s/^#create_main_cluster.*/create_main_cluster=false/g" /etc/postgresql-common/createcluster.conf
 
-        apt-get install -y python3.6 python3.6-dev python3.6-venv python3.7 python3.7-dev python3.7-venv python3.8 python3.8-dev python3.8-venv python3.9 python3.9-dev python3.9-venv
+        apt-get install -y python{3.7,3.8,3.9,3.10} python{3.7,3.8,3.9,3.10}-dev python{3.7,3.8,3.9,3.10}-venv
         apt-get install -y postgresql-{10,11,12,13,14} postgresql-server-dev-{10,11,12,13,14}
 
         username="$(< /dev/urandom tr -dc a-z | head -c${1:-32};echo;)"
@@ -75,7 +68,7 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", inline: $script, privileged: true
 
     $script = <<-SCRIPT
-        versions=(3.6 3.7 3.8 3.9)
+        versions=(3.7 3.8 3.9 3.10)
         for version in "${versions[@]}"; do
             python${version} -m venv venv${version}
             source ~/venv${version}/bin/activate

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -54,34 +54,42 @@ Vagrant
 =======
 
 The Vagrantfile can be used to setup a vagrant development environment.   The vagrant environment has
-python 3.6, 3.7, 3.8 and 3.9 virtual environments and installations of postgresql 10 and newer.
+python 3.7, 3.8, 3.9 and 3.10 virtual environments and installations of postgresql 10, 11 and 12, 13 and 14.
 
-By default vagrant up will start a Virtualbox environment.   The Vagrantfile will also work for libvirt, just prefix
-VAGRANT_DEFAULT_PROVIDER=libvirt to the vagrant up command.
+By default vagrant up will start a Virtualbox environment. The Vagrantfile will also work for libvirt, just prefix
+``VAGRANT_DEFAULT_PROVIDER=libvirt`` to the ``vagrant up`` command.
+
+Any combination of Python (3.7, 3.8, 3.9 and 3.10) and Postgresql (10, 11, 12, 13 and 14)
 
 Bring up vagrant instance and connect via ssh::
 
-vagrant up
-vagrant ssh
-vagrant@ubuntu2004:~$ cd /vagrant
+  vagrant up
+  vagrant ssh
+  vagrant@ubuntu2004:~$ cd /vagrant
 
-Test with Python 3.7 and Postgresql 10
+Test with Python 3.7 and Postgresql 10::
 
-vagrant@ubuntu2004:~$ source ~/venv3.7/bin/activate
-vagrant@ubuntu2004:~$ PG_VERSION=10 make unittest
-vagrant@ubuntu2004:~$ deactivate
+  vagrant@ubuntu2004:~$ source ~/venv3.7/bin/activate
+  vagrant@ubuntu2004:~$ PG_VERSION=10 make unittest
+  vagrant@ubuntu2004:~$ deactivate
 
-Test with Python 3.8 and Postgresql 11
+Test with Python 3.8 and Postgresql 11::
 
-vagrant@ubuntu2004:~$ source ~/venv3.8/bin/activate
-vagrant@ubuntu2004:~$ PG_VERSION=11 make unittest
-vagrant@ubuntu2004:~$ deactivate
+  vagrant@ubuntu2004:~$ source ~/venv3.8/bin/activate
+  vagrant@ubuntu2004:~$ PG_VERSION=11 make unittest
+  vagrant@ubuntu2004:~$ deactivate
 
-Test with Python 3.9 and Postgresql 12
+Test with Python 3.9 and Postgresql 12::
 
-vagrant@ubuntu2004:~$ source ~/venv3.9/bin/activate
-vagrant@ubuntu2004:~$ PG_VERSION=12 make unittest
-vagrant@ubuntu2004:~$ deactivate
+  vagrant@ubuntu2004:~$ source ~/venv3.9/bin/activate
+  vagrant@ubuntu2004:~$ PG_VERSION=12 make unittest
+  vagrant@ubuntu2004:~$ deactivate
+
+Test with Python 3.10 and Postgresql 13::
+
+  vagrant@ubuntu2004:~$ source ~/venv3.10/bin/activate
+  vagrant@ubuntu2004:~$ PG_VERSION=13 make unittest
+  vagrant@ubuntu2004:~$ deactivate
 
 And so on
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
Adds python 3.10, removes python 3.6.
Removes the ng_apt_cacher support which never worked due to a bug

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
