### PR TITLE
tests: fix flakiness while starting PostgreSQL and PGHoard webserver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     strategy:
-      max-parallel: 4
+      max-parallel: 5
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 

--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -323,11 +323,13 @@ class WALFileDeleterThread(PGHoardThread):
         self.metrics = metrics
         self.wal_file_deletion_queue = wal_file_deletion_queue
         self.running = True
+        self.min_sleep_between_events = 0.0
         self.to_be_deleted_files: Dict[str, Set[Path]] = defaultdict(set)
         self.log.debug("WALFileDeleter initialized")
 
     def run_safe(self):
         while self.running:
+            time.sleep(self.min_sleep_between_events)
             wait_timeout = 1.0
             # config can be changed in another thread, so we have to lookup this within the loop
             config_wait_timeout = self.config.get("deleter_event_get_timeout", wait_timeout)

--- a/pghoard/webserver.py
+++ b/pghoard/webserver.py
@@ -9,6 +9,7 @@ import logging
 import os
 import socket
 import tempfile
+import threading
 import time
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
@@ -81,6 +82,7 @@ class WebServer(PGHoardThread):
         self.download_results = Queue()
         self._running = False
         self.log.debug("WebServer initialized with address: %r port: %r", self.address, self.port)
+        self.is_initialized = threading.Event()
 
     def run_safe(self):
         # We bind the port only when we start running
@@ -104,6 +106,7 @@ class WebServer(PGHoardThread):
         # later on in the object store.
         self.server.prefetch_404 = deque(maxlen=32)  # pylint: disable=attribute-defined-outside-init
         self.server.metrics = self.metrics  # pylint: disable=attribute-defined-outside-init
+        self.is_initialized.set()
         self.server.serve_forever()
 
     def close(self):

--- a/test/util.py
+++ b/test/util.py
@@ -35,6 +35,7 @@ def switch_wal(connection):
     # Note: do not combine two function call in one select, PG executes it differently and
     # sometimes looks like it generates less WAL files than we wanted
     cur.execute("SELECT txid_current()")
+    cur.execute("CHECKPOINT")
     if connection.server_version >= 100000:
         cur.execute("SELECT pg_switch_wal()")
     else:
@@ -44,6 +45,7 @@ def switch_wal(connection):
     # switching, the bug should be fixed in PG 15
     # https://github.com/postgres/postgres/commit/596ba75cb11173a528c6b6ec0142a282e42b69ec
     cur.execute("SELECT txid_current()")
+    cur.execute("CHECKPOINT")
     cur.close()
 
 


### PR DESCRIPTION
# About this change - What it does

The tests were waiting a fixed amount of time for the web server thread
and for PostgreSQL to start. This was too optimistic. Fix it by using an
threading Event or polling the process startup instead.

# Why this way

Because flaky tests are unpleasant.