### PR TITLE
don't encrypt the local-tar metadata file, so it can be accessed with…

### DIFF
--- a/pghoard/basebackup/base.py
+++ b/pghoard/basebackup/base.py
@@ -721,6 +721,7 @@ class PGBaseBackup(PGHoardThread):
             temp_dir=compressed_base,
             files_to_backup=control_files,
             file_type=FileType.Basebackup,
+            encrypt=False, # do not encrypt the metadata file
             extra_metadata={
                 **self.metadata,
                 "end-time": backup_end_time,


### PR DESCRIPTION
…out the private key when doing delta backups

<!-- All contributors please complete these sections, including maintainers -->
This makes it possible to only use the public key for backups, and only need the private key for restores.   This issue only occurs when trying to remove old backups, without the private key being in the config file, its impossible to open the metadata file and thus remove the old data files.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->

# Why this way
The metadata file does not have any sensitive information, so encrypting it seemed a bit pointless and I made the simplest change that could possibly work.


