### PR TITLE
walreceiver: stop replication when stopping thread 

### DIFF
--- a/test/test_walreceiver.py
+++ b/test/test_walreceiver.py
@@ -70,7 +70,7 @@ class TestWalReceiver:
         previous_wal_name = lsn.previous_walfile_start_lsn.walfile_name
         pghoard.start_walreceiver(pghoard.test_site, node, last_flushed_lsn)
         wait_for_xlog(pghoard, 4)
-        last_flushed_lsn = stop_walreceiver(pghoard)
+        stop_walreceiver(pghoard)
         state = get_transfer_agent_upload_xlog_state(pghoard)
         assert state.get("xlogs_since_basebackup") == 4
         assert state.get("latest_filename") == previous_wal_name

--- a/test/test_walreceiver.py
+++ b/test/test_walreceiver.py
@@ -43,13 +43,13 @@ class TestWalReceiver:
         else:
             node["slot"] = replication_slot
 
-        # The transfer agent state will be used to check what
-        # was uploaded
-        # Before starting the walreceiver, get the current wal name.
-        wal_name = get_current_lsn(node).walfile_name
-        # Start streaming, force a wal rotation, and check the wal has been
-        # archived
+        # The transfer agent state will be used to check what was uploaded
+        # Start streaming
         pghoard.start_walreceiver(pghoard.test_site, node, None)
+        # Get the initial wal name of the server
+        pghoard.walreceivers[pghoard.test_site].initial_lsn_available.wait()
+        wal_name = pghoard.walreceivers[pghoard.test_site].initial_lsn.walfile_name
+        #  Force a wal rotation
         switch_wal(conn)
         # Check that we uploaded one file, and it is the right one.
         wait_for_xlog(pghoard, 1)


### PR DESCRIPTION
This avoids failures when starting the replication twice (mainly in tests).