### PR TITLE
Allow the restore operation to mark a backup as preserved

### DIFF
--- a/pghoard/object_store.py
+++ b/pghoard/object_store.py
@@ -1,0 +1,110 @@
+"""
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+import datetime
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from requests import Session
+from rohmu import dates
+
+
+class ObjectStore:
+    def __init__(self, storage, prefix, site, pgdata):
+        self.storage = storage
+        self.prefix = prefix
+        self.site = site
+        self.pgdata = pgdata
+        self.log = logging.getLogger(self.__class__.__name__)
+
+    def list_basebackups(self):
+        return self.storage.list_path(os.path.join(self.prefix, "basebackup"))
+
+    def try_request_backup_preservation(self, basebackup: str, preserve_until: datetime.datetime) -> Optional[str]:
+        try:
+            return self.request_backup_preservation(basebackup, preserve_until)
+        except Exception:  # pylint: disable=broad-except
+            # rohmu does not wrap storage implementation errors in high-level errors:
+            # we can't catch something more specific like "permission denied".
+            self.log.exception("Could not request backup preservation")
+            return None
+
+    def try_cancel_backup_preservation(self, request_name: str) -> None:
+        try:
+            self.cancel_backup_preservation(request_name)
+        except Exception:  # pylint: disable=broad-except
+            # rohmu does not wrap storage implementation errors in high-level errors:
+            # we can't catch something more specific like "permission denied".
+            self.log.exception("Could not cancel backup preservation")
+
+    def request_backup_preservation(self, basebackup: str, preserve_until: datetime.datetime) -> str:
+        backup_name = Path(basebackup).name
+        request_name = f"{backup_name}_{preserve_until}"
+        request_path = os.path.join(self.prefix, "preservation_request", request_name)
+        self.storage.store_file_from_memory(
+            request_path, b"", {
+                "preserve-backup": backup_name,
+                "preserve-until": str(preserve_until)
+            }
+        )
+        return request_name
+
+    def cancel_backup_preservation(self, request_name: str) -> None:
+        request_path = os.path.join(self.prefix, "preservation_request", request_name)
+        self.storage.delete_key(request_path)
+
+    def show_basebackup_list(self, verbose=True):
+        result = self.list_basebackups()
+        caption = "Available %r basebackups:" % self.site
+        print_basebackup_list(result, caption=caption, verbose=verbose)
+
+    def get_basebackup_metadata(self, basebackup):
+        return self.storage.get_metadata_for_key(basebackup)
+
+    def get_basebackup_file_to_fileobj(self, basebackup, fileobj, *, progress_callback=None):
+        return self.storage.get_contents_to_fileobj(basebackup, fileobj, progress_callback=progress_callback)
+
+    def get_file_bytes(self, name):
+        return self.storage.get_contents_to_string(name)[0]
+
+
+class HTTPRestore(ObjectStore):
+    def __init__(self, host, port, site, pgdata=None):
+        super().__init__(storage=None, prefix=None, site=site, pgdata=pgdata)
+        self.host = host
+        self.port = port
+        self.session = Session()
+
+    def _url(self, path):
+        return "http://{host}:{port}/{site}/{path}".format(host=self.host, port=self.port, site=self.site, path=path)
+
+    def list_basebackups(self):
+        response = self.session.get(self._url("basebackup"))
+        return response.json()["basebackups"]
+
+
+def print_basebackup_list(basebackups, *, caption="Available basebackups", verbose=True):
+    print(caption, "\n")
+    fmt = "{name:40}  {size:>11}  {orig_size:>11}  {time:20}".format
+    print(fmt(name="Basebackup", size="Backup size", time="Start time", orig_size="Orig size"))
+    print(fmt(name="-" * 40, size="-" * 11, time="-" * 20, orig_size="-" * 11))
+    for b in sorted(basebackups, key=lambda b: b["name"]):
+        meta = b["metadata"].copy()
+        lm = meta.pop("start-time")
+        if isinstance(lm, str):
+            lm = dates.parse_timestamp(lm)
+        if lm.tzinfo:
+            lm = lm.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+        lm_str = lm.isoformat()[:19] + "Z"  # # pylint: disable=no-member
+        size_str = "{} MB".format(int(meta.get("total-size-enc", b["size"])) // (1024 ** 2))
+        orig_size = int(meta.get("total-size-plain", meta.get("original-file-size")) or 0)
+        if orig_size:
+            orig_size_str = "{} MB".format(orig_size // (1024 ** 2))
+        else:
+            orig_size_str = "n/a"
+        print(fmt(name=b["name"], size=size_str, time=lm_str, orig_size=orig_size_str))
+        if verbose:
+            print("    metadata:", meta)

--- a/pghoard/preservation_request.py
+++ b/pghoard/preservation_request.py
@@ -1,0 +1,32 @@
+"""
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+import datetime
+from typing import Any, Mapping, Sequence
+
+from rohmu import dates
+
+
+def patch_basebackup_metadata_with_preservation(
+    basebackup_entry: Mapping[str, Any],
+    backups_to_preserve: Mapping[str, datetime.datetime],
+) -> None:
+    basebackup_entry["metadata"]["preserve-until"] = backups_to_preserve.get(basebackup_entry["name"])
+
+
+def is_basebackup_preserved(basebackup_entry: Mapping[str, Any], now: datetime.datetime) -> bool:
+    preserve_until = basebackup_entry["metadata"].get("preserve-until")
+    return preserve_until is not None and preserve_until > now
+
+
+def parse_preservation_requests(preservation_requests: Sequence[Mapping[str, Any]], ) -> Mapping[str, datetime.datetime]:
+    backups_to_preserve = {}
+    for preservation_request in preservation_requests:
+        backup_name = preservation_request["metadata"]["preserve-backup"]
+        preserve_until = dates.parse_timestamp(preservation_request["metadata"]["preserve-until"])
+        if backup_name in backups_to_preserve:
+            backups_to_preserve[backup_name] = max(backups_to_preserve[backup_name], preserve_until)
+        else:
+            backups_to_preserve[backup_name] = preserve_until
+    return backups_to_preserve

--- a/pghoard/preservation_request.py
+++ b/pghoard/preservation_request.py
@@ -21,7 +21,7 @@ def is_basebackup_preserved(basebackup_entry: Mapping[str, Any], now: datetime.d
 
 
 def parse_preservation_requests(preservation_requests: Sequence[Mapping[str, Any]], ) -> Mapping[str, datetime.datetime]:
-    backups_to_preserve = {}
+    backups_to_preserve: dict[str, datetime.datetime] = {}
     for preservation_request in preservation_requests:
         backup_name = preservation_request["metadata"]["preserve-backup"]
         preserve_until = dates.parse_timestamp(preservation_request["metadata"]["preserve-until"])

--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -8,7 +8,6 @@ import abc
 import argparse
 import base64
 import contextlib
-import datetime
 import enum
 import errno
 import io
@@ -27,18 +26,17 @@ import uuid
 from dataclasses import dataclass, field
 from distutils.version import \
     LooseVersion  # pylint: disable=no-name-in-module,import-error
-from pathlib import Path
 from threading import RLock
 from typing import Any, Dict, List, Optional, Set, Union
 
 from psycopg2.extensions import adapt
-from requests import Session
 from rohmu import dates, get_transfer, rohmufile
 from rohmu.errors import (Error, InvalidConfigurationError, MaybeRecoverableError)
 
 from pghoard.common import (
     BaseBackupFormat, FileType, FileTypePrefixes, StrEnum, download_backup_meta_file, extract_pghoard_delta_metadata
 )
+from pghoard.object_store import (HTTPRestore, ObjectStore, print_basebackup_list)
 
 from . import common, config, logutil, version
 from .postgres_command import PGHOARD_HOST, PGHOARD_PORT
@@ -177,30 +175,6 @@ def create_recovery_conf(
 
     os.rename(filepath_tmp, filepath)
     return content
-
-
-def print_basebackup_list(basebackups, *, caption="Available basebackups", verbose=True):
-    print(caption, "\n")
-    fmt = "{name:40}  {size:>11}  {orig_size:>11}  {time:20}".format
-    print(fmt(name="Basebackup", size="Backup size", time="Start time", orig_size="Orig size"))
-    print(fmt(name="-" * 40, size="-" * 11, time="-" * 20, orig_size="-" * 11))
-    for b in sorted(basebackups, key=lambda b: b["name"]):
-        meta = b["metadata"].copy()
-        lm = meta.pop("start-time")
-        if isinstance(lm, str):
-            lm = dates.parse_timestamp(lm)
-        if lm.tzinfo:
-            lm = lm.astimezone(datetime.timezone.utc).replace(tzinfo=None)
-        lm_str = lm.isoformat()[:19] + "Z"  # # pylint: disable=no-member
-        size_str = "{} MB".format(int(meta.get("total-size-enc", b["size"])) // (1024 ** 2))
-        orig_size = int(meta.get("total-size-plain", meta.get("original-file-size")) or 0)
-        if orig_size:
-            orig_size_str = "{} MB".format(orig_size // (1024 ** 2))
-        else:
-            orig_size_str = "n/a"
-        print(fmt(name=b["name"], size=size_str, time=lm_str, orig_size=orig_size_str))
-        if verbose:
-            print("    metadata:", meta)
 
 
 class Restore:
@@ -1019,80 +993,6 @@ class ChunkFetcher:
                         "tar exited with code {!r} for file {!r}, output: {!r}".format(exit_code, file_name, output)
                     )
             self.log.info("Processing of %r completed successfully", file_name)
-
-
-class ObjectStore:
-    def __init__(self, storage, prefix, site, pgdata):
-        self.storage = storage
-        self.prefix = prefix
-        self.site = site
-        self.pgdata = pgdata
-        self.log = logging.getLogger(self.__class__.__name__)
-
-    def list_basebackups(self):
-        return self.storage.list_path(os.path.join(self.prefix, "basebackup"))
-
-    def try_request_backup_preservation(self, basebackup: str, preserve_until: datetime.datetime) -> Optional[str]:
-        try:
-            return self.request_backup_preservation(basebackup, preserve_until)
-        except Exception:  # pylint: disable=broad-except
-            # rohmu does not wrap storage implementation errors in high-level errors:
-            # we can't catch something more specific like "permission denied".
-            self.log.exception("Could not request backup preservation")
-            return None
-
-    def try_cancel_backup_preservation(self, request_name: str) -> None:
-        try:
-            self.cancel_backup_preservation(request_name)
-        except Exception:  # pylint: disable=broad-except
-            # rohmu does not wrap storage implementation errors in high-level errors:
-            # we can't catch something more specific like "permission denied".
-            self.log.exception("Could not cancel backup preservation")
-
-    def request_backup_preservation(self, basebackup: str, preserve_until: datetime.datetime) -> str:
-        backup_name = Path(basebackup).name
-        request_name = f"{backup_name}_{preserve_until}"
-        request_path = os.path.join(self.prefix, "preservation_request", request_name)
-        self.storage.store_file_from_memory(
-            request_path, b"", {
-                "preserve-backup": backup_name,
-                "preserve-until": str(preserve_until)
-            }
-        )
-        return request_name
-
-    def cancel_backup_preservation(self, request_name: str) -> None:
-        request_path = os.path.join(self.prefix, "preservation_request", request_name)
-        self.storage.delete_key(request_path)
-
-    def show_basebackup_list(self, verbose=True):
-        result = self.list_basebackups()
-        caption = "Available %r basebackups:" % self.site
-        print_basebackup_list(result, caption=caption, verbose=verbose)
-
-    def get_basebackup_metadata(self, basebackup):
-        return self.storage.get_metadata_for_key(basebackup)
-
-    def get_basebackup_file_to_fileobj(self, basebackup, fileobj, *, progress_callback=None):
-        return self.storage.get_contents_to_fileobj(basebackup, fileobj, progress_callback=progress_callback)
-
-    def get_file_bytes(self, name):
-        return self.storage.get_contents_to_string(name)[0]
-
-
-class HTTPRestore(ObjectStore):
-    def __init__(self, host, port, site, pgdata=None):
-        super().__init__(storage=None, prefix=None, site=site, pgdata=pgdata)
-        self.host = host
-        self.port = port
-        self.session = Session()
-
-    def _url(self, path):
-        return "http://{host}:{port}/{site}/{path}".format(host=self.host, port=self.port, site=self.site, path=path)
-
-    def list_basebackups(self):
-        response = self.session.get(self._url("basebackup"))
-        return response.json()["basebackups"]
 
 
 def main():

--- a/test/test_object_store.py
+++ b/test/test_object_store.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2022 Aiven, Helsinki, Finland. https://aiven.io/
+import datetime
+from pathlib import Path
+
+from rohmu.object_storage.local import LocalTransfer
+
+from pghoard.object_store import ObjectStore
+
+
+def test_object_store_request_backup_preservation(tmp_path: Path) -> None:
+    storage_dir = tmp_path / "storage"
+    storage_dir.mkdir()
+    storage = LocalTransfer(directory=str(storage_dir))
+    store = ObjectStore(storage, prefix="site_name", site=None, pgdata=str(tmp_path / "pgdata"))
+    preserve_until = datetime.datetime(2022, 12, 18, 10, 20, 30, 123456, tzinfo=datetime.timezone.utc)
+    request_name = store.request_backup_preservation("2022_12_10", preserve_until=preserve_until)
+    requests = storage.list_path("site_name/preservation_request")
+    assert len(requests) == 1
+    assert requests[0]["name"] == f"site_name/preservation_request/{request_name}"
+    assert requests[0]["metadata"]["preserve-backup"] == "2022_12_10"
+    assert requests[0]["metadata"]["preserve-until"] == "2022-12-18 10:20:30.123456+00:00"
+
+
+def test_object_store_cancel_backup_preservation(tmp_path: Path) -> None:
+    storage_dir = tmp_path / "storage"
+    storage_dir.mkdir()
+    storage = LocalTransfer(directory=str(storage_dir))
+    store = ObjectStore(storage, prefix="site_name", site=None, pgdata=str(tmp_path / "pgdata"))
+    preserve_until = datetime.datetime(2022, 12, 18, 10, 20, 30, 123456, tzinfo=datetime.timezone.utc)
+    request_name = store.request_backup_preservation("2022_12_10", preserve_until=preserve_until)
+    store.cancel_backup_preservation(request_name)
+    requests = storage.list_path("site_name/preservation_request")
+    assert len(requests) == 0

--- a/test/test_object_store.py
+++ b/test/test_object_store.py
@@ -31,3 +31,31 @@ def test_object_store_cancel_backup_preservation(tmp_path: Path) -> None:
     store.cancel_backup_preservation(request_name)
     requests = storage.list_path("site_name/preservation_request")
     assert len(requests) == 0
+
+
+def test_object_store_try_request_backup_preservation_returns_none_on_failure(tmp_path: Path) -> None:
+    storage_dir = tmp_path / "storage"
+    storage_dir.mkdir()
+    storage_dir.chmod(0o000)
+    try:
+        storage = LocalTransfer(directory=str(storage_dir))
+        store = ObjectStore(storage, prefix="site_name", site=None, pgdata=str(tmp_path / "pgdata"))
+        preserve_until = datetime.datetime(2022, 12, 18, 10, 20, 30, 123456, tzinfo=datetime.timezone.utc)
+        request_name = store.try_request_backup_preservation("2022_12_10", preserve_until=preserve_until)
+        assert request_name is None
+    finally:
+        storage_dir.chmod(0o700)
+
+
+def test_object_store_try_cancel_backup_preservation_silently_fails(tmp_path: Path) -> None:
+    storage_dir = tmp_path / "storage"
+    storage_dir.mkdir()
+    storage = LocalTransfer(directory=str(storage_dir))
+    store = ObjectStore(storage, prefix="site_name", site=None, pgdata=str(tmp_path / "pgdata"))
+    preserve_until = datetime.datetime(2022, 12, 18, 10, 20, 30, 123456, tzinfo=datetime.timezone.utc)
+    request_name = store.request_backup_preservation("2022_12_10", preserve_until=preserve_until)
+    storage_dir.chmod(0o000)
+    try:
+        store.try_cancel_backup_preservation(request_name)
+    finally:
+        storage_dir.chmod(0o700)

--- a/test/test_preservation_request.py
+++ b/test/test_preservation_request.py
@@ -1,0 +1,74 @@
+"""
+Copyright (c) 2022 Aiven Ltd
+See LICENSE for details
+"""
+import datetime
+
+from pghoard.preservation_request import (
+    is_basebackup_preserved, parse_preservation_requests, patch_basebackup_metadata_with_preservation
+)
+
+
+def test_patch_basebackup_metadata_with_preservation() -> None:
+    preserve_until = datetime.datetime(2022, 12, 26, 10, 20, tzinfo=datetime.timezone.utc)
+    basebackup_entry = {"name": "2022_12_20", "metadata": {}}
+    backups_to_preserve = {"2022_12_20": preserve_until}
+    patch_basebackup_metadata_with_preservation(basebackup_entry, backups_to_preserve)
+    assert basebackup_entry["metadata"]["preserve-until"] == preserve_until
+
+
+def test_patch_basebackup_metadata_with_preservation_with_no_match() -> None:
+    basebackup_entry = {"name": "2022_12_20", "metadata": {}}
+    backups_to_preserve = {"2022_12_14": datetime.datetime(2022, 12, 20, 10, 20, 30, 123456)}
+    patch_basebackup_metadata_with_preservation(basebackup_entry, backups_to_preserve)
+    assert basebackup_entry["metadata"]["preserve-until"] is None
+
+
+def test_is_backup_preserved_no_metadata() -> None:
+    now = datetime.datetime(2022, 12, 26, 10, 20, tzinfo=datetime.timezone.utc)
+    basebackup_entry = {"name": "2022_12_20", "metadata": {}}
+    assert is_basebackup_preserved(basebackup_entry, now) is False
+
+
+def test_is_backup_preserved_none_metadata() -> None:
+    now = datetime.datetime(2022, 12, 26, 10, 20, tzinfo=datetime.timezone.utc)
+    basebackup_entry = {"name": "2022_12_20", "metadata": {"preserve-until": None}}
+    assert is_basebackup_preserved(basebackup_entry, now) is False
+
+
+def test_is_backup_preserved_metadata_in_past() -> None:
+    now = datetime.datetime(2022, 12, 26, 10, 20, tzinfo=datetime.timezone.utc)
+    preserve_until = datetime.datetime(2022, 12, 26, tzinfo=datetime.timezone.utc)
+    basebackup_entry = {"name": "2022_12_20", "metadata": {"preserve-until": preserve_until}}
+    assert is_basebackup_preserved(basebackup_entry, now) is False
+
+
+def test_is_backup_preserved_metadata_in_future() -> None:
+    now = datetime.datetime(2022, 12, 24, tzinfo=datetime.timezone.utc)
+    preserve_until = datetime.datetime(2022, 12, 26, tzinfo=datetime.timezone.utc)
+    basebackup_entry = {"name": "2022_12_20", "metadata": {"preserve-until": preserve_until}}
+    assert is_basebackup_preserved(basebackup_entry, now) is True
+
+
+def test_parse_preservation_requests() -> None:
+    preservation_requests = [{
+        "metadata": {
+            "preserve-backup": "2022_12_10",
+            "preserve-until": "2022-12-18 10:20:30.123456"
+        }
+    }, {
+        "metadata": {
+            "preserve-backup": "2022_12_10",
+            "preserve-until": "2022-12-16 10:20:30.123456"
+        }
+    }, {
+        "metadata": {
+            "preserve-backup": "2022_12_20",
+            "preserve-until": "2022-12-26 10:20:30.123456+00:00"
+        }
+    }]
+    backups_to_preserve = parse_preservation_requests(preservation_requests)
+    assert backups_to_preserve == {
+        "2022_12_10": datetime.datetime(2022, 12, 18, 10, 20, 30, 123456, tzinfo=datetime.timezone.utc),
+        "2022_12_20": datetime.datetime(2022, 12, 26, 10, 20, 30, 123456, tzinfo=datetime.timezone.utc),
+    }

--- a/test/test_preservation_request.py
+++ b/test/test_preservation_request.py
@@ -3,6 +3,7 @@ Copyright (c) 2022 Aiven Ltd
 See LICENSE for details
 """
 import datetime
+from typing import Any
 
 from pghoard.preservation_request import (
     is_basebackup_preserved, parse_preservation_requests, patch_basebackup_metadata_with_preservation
@@ -11,14 +12,14 @@ from pghoard.preservation_request import (
 
 def test_patch_basebackup_metadata_with_preservation() -> None:
     preserve_until = datetime.datetime(2022, 12, 26, 10, 20, tzinfo=datetime.timezone.utc)
-    basebackup_entry = {"name": "2022_12_20", "metadata": {}}
+    basebackup_entry: dict[str, Any] = {"name": "2022_12_20", "metadata": {}}
     backups_to_preserve = {"2022_12_20": preserve_until}
     patch_basebackup_metadata_with_preservation(basebackup_entry, backups_to_preserve)
     assert basebackup_entry["metadata"]["preserve-until"] == preserve_until
 
 
 def test_patch_basebackup_metadata_with_preservation_with_no_match() -> None:
-    basebackup_entry = {"name": "2022_12_20", "metadata": {}}
+    basebackup_entry: dict[str, Any] = {"name": "2022_12_20", "metadata": {}}
     backups_to_preserve = {"2022_12_14": datetime.datetime(2022, 12, 20, 10, 20, 30, 123456)}
     patch_basebackup_metadata_with_preservation(basebackup_entry, backups_to_preserve)
     assert basebackup_entry["metadata"]["preserve-until"] is None

--- a/test/test_restore.py
+++ b/test/test_restore.py
@@ -14,14 +14,17 @@ import os
 import shutil
 import time
 import unittest
+from pathlib import Path
 from tempfile import mkdtemp
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from rohmu.object_storage.local import LocalTransfer
 
 from pghoard.common import write_json_file
 from pghoard.restore import (
-    BasebackupFetcher, ChunkFetcher, FileDataInfo, FileInfoType, FilePathInfo, Restore, RestoreError, create_recovery_conf
+    BasebackupFetcher, ChunkFetcher, FileDataInfo, FileInfoType, FilePathInfo, ObjectStore, Restore, RestoreError,
+    create_recovery_conf
 )
 
 from .base import PGHoardTestCase
@@ -575,3 +578,29 @@ def test_restore_get_delta_basebackup_data():
         ),
     ]
     assert all(f in files for f in expected_files)
+
+
+def test_object_store_request_backup_preservation(tmp_path: Path) -> None:
+    storage_dir = tmp_path / "storage"
+    storage_dir.mkdir()
+    storage = LocalTransfer(directory=str(storage_dir))
+    store = ObjectStore(storage, prefix="site_name", site=None, pgdata=str(tmp_path / "pgdata"))
+    preserve_until = datetime.datetime(2022, 12, 18, 10, 20, 30, 123456, tzinfo=datetime.timezone.utc)
+    request_name = store.request_backup_preservation("2022_12_10", preserve_until=preserve_until)
+    requests = storage.list_path("site_name/preservation_request")
+    assert len(requests) == 1
+    assert requests[0]["name"] == f"site_name/preservation_request/{request_name}"
+    assert requests[0]["metadata"]["preserve-backup"] == "2022_12_10"
+    assert requests[0]["metadata"]["preserve-until"] == "2022-12-18 10:20:30.123456+00:00"
+
+
+def test_object_store_cancel_backup_preservation(tmp_path: Path) -> None:
+    storage_dir = tmp_path / "storage"
+    storage_dir.mkdir()
+    storage = LocalTransfer(directory=str(storage_dir))
+    store = ObjectStore(storage, prefix="site_name", site=None, pgdata=str(tmp_path / "pgdata"))
+    preserve_until = datetime.datetime(2022, 12, 18, 10, 20, 30, 123456, tzinfo=datetime.timezone.utc)
+    request_name = store.request_backup_preservation("2022_12_10", preserve_until=preserve_until)
+    store.cancel_backup_preservation(request_name)
+    requests = storage.list_path("site_name/preservation_request")
+    assert len(requests) == 0

--- a/test/test_restore.py
+++ b/test/test_restore.py
@@ -14,17 +14,14 @@ import os
 import shutil
 import time
 import unittest
-from pathlib import Path
 from tempfile import mkdtemp
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from rohmu.object_storage.local import LocalTransfer
 
 from pghoard.common import write_json_file
 from pghoard.restore import (
-    BasebackupFetcher, ChunkFetcher, FileDataInfo, FileInfoType, FilePathInfo, ObjectStore, Restore, RestoreError,
-    create_recovery_conf
+    BasebackupFetcher, ChunkFetcher, FileDataInfo, FileInfoType, FilePathInfo, Restore, RestoreError, create_recovery_conf
 )
 
 from .base import PGHoardTestCase
@@ -578,29 +575,3 @@ def test_restore_get_delta_basebackup_data():
         ),
     ]
     assert all(f in files for f in expected_files)
-
-
-def test_object_store_request_backup_preservation(tmp_path: Path) -> None:
-    storage_dir = tmp_path / "storage"
-    storage_dir.mkdir()
-    storage = LocalTransfer(directory=str(storage_dir))
-    store = ObjectStore(storage, prefix="site_name", site=None, pgdata=str(tmp_path / "pgdata"))
-    preserve_until = datetime.datetime(2022, 12, 18, 10, 20, 30, 123456, tzinfo=datetime.timezone.utc)
-    request_name = store.request_backup_preservation("2022_12_10", preserve_until=preserve_until)
-    requests = storage.list_path("site_name/preservation_request")
-    assert len(requests) == 1
-    assert requests[0]["name"] == f"site_name/preservation_request/{request_name}"
-    assert requests[0]["metadata"]["preserve-backup"] == "2022_12_10"
-    assert requests[0]["metadata"]["preserve-until"] == "2022-12-18 10:20:30.123456+00:00"
-
-
-def test_object_store_cancel_backup_preservation(tmp_path: Path) -> None:
-    storage_dir = tmp_path / "storage"
-    storage_dir.mkdir()
-    storage = LocalTransfer(directory=str(storage_dir))
-    store = ObjectStore(storage, prefix="site_name", site=None, pgdata=str(tmp_path / "pgdata"))
-    preserve_until = datetime.datetime(2022, 12, 18, 10, 20, 30, 123456, tzinfo=datetime.timezone.utc)
-    request_name = store.request_backup_preservation("2022_12_10", preserve_until=preserve_until)
-    store.cancel_backup_preservation(request_name)
-    requests = storage.list_path("site_name/preservation_request")
-    assert len(requests) == 0

--- a/test/test_webserver.py
+++ b/test/test_webserver.py
@@ -21,9 +21,10 @@ from rohmu.encryptor import Encryptor
 from pghoard import postgres_command, wal
 from pghoard.archive_sync import ArchiveSync
 from pghoard.common import get_pg_wal_directory
+from pghoard.object_store import HTTPRestore
 from pghoard.pgutil import create_connection_string
 from pghoard.postgres_command import archive_command, restore_command
-from pghoard.restore import HTTPRestore, Restore
+from pghoard.restore import Restore
 
 # pylint: disable=attribute-defined-outside-init
 from .base import CONSTANT_TEST_RSA_PRIVATE_KEY, CONSTANT_TEST_RSA_PUBLIC_KEY


### PR DESCRIPTION
## About this change - What it does
A preserved backup won't be automatically deleted even if it matches
the automatic deletion rules.

The backups following the preserved backup won't be deleted either.

This capability is enabled by passing the `--preserve-until` flag
during restoration.

Multiple preservation requests can co-exist and be separately
canceled for the same backup.

The effective preservation duration is the longest of all the
uncancelled preservation requests.

If the storage is not writable and the option was enabled, pghoard
will emit an error message but will not fail the restoration.

The preservation request is canceled at the end of the restore
operation, only if the restoration is successful..

## Why this way

The request is not renewed or extended during the backup restoration.
The expectation is that the option is used with a far enough date is
the future that it's not a problem.

Using a far-future date is unlikely to cause issues during normal
operations since the request is canceled after a successful restore.

If needed, an operator could write a preservation request in the
storage from outside pghoard, pghoard will see it and honour it
