### PR TITLE
Bump the minimal psycpog2 version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     packages=find_packages(exclude=["test"]),
     install_requires=[
         "cryptography",
-        "psycopg2 >= 2.0.0",
+        "psycopg2 >= 2.8.0",
         "pydantic",
         "python-dateutil",
         "python-snappy >= 0.5",


### PR DESCRIPTION
We use the psycopg2.errors package, introduced in psycpog2 2.8. We should reflect that in our dependencies.

See #579