### PR TITLE
Provide a metric measuring basebackup upload rate

### DIFF
--- a/pghoard/basebackup/base.py
+++ b/pghoard/basebackup/base.py
@@ -225,11 +225,12 @@ class PGBaseBackup(PGHoardThread):
 
                     metadata.update({"start-wal-segment": start_wal_segment, "start-time": start_time})
 
-            def progress_callback():
+            def progress_callback(n_bytes: int = 1) -> None:
                 stderr_data = proc.stderr.read()
                 if stderr_data:
                     self.latest_activity = datetime.datetime.utcnow()
                     self.log.debug("pg_basebackup stderr: %r", stderr_data)
+                self.metrics.increase("pghoard.basebackup_bytes_uploaded", inc_value=n_bytes, tags={"delta": False})
 
             original_input_size, compressed_file_size = rohmufile.write_file(
                 input_obj=proc.stdout,

--- a/pghoard/basebackup/delta.py
+++ b/pghoard/basebackup/delta.py
@@ -125,6 +125,9 @@ class DeltaBaseBackup:
 
         result_hash = hashlib.blake2s()
 
+        def progress_callback(n_bytes: int = 1) -> None:
+            self.metrics.increase("pghoard.basebackup_bytes_uploaded", inc_value=n_bytes, tags={"delta": True})
+
         with NamedTemporaryFile(dir=temp_dir, prefix=os.path.basename(chunk_path), suffix=".tmp") as raw_output_obj:
             rohmufile.write_file(
                 input_obj=file_obj,
@@ -133,7 +136,8 @@ class DeltaBaseBackup:
                 compression_level=self.compression_data.level,
                 rsa_public_key=self.encryption_data.rsa_public_key,
                 log_func=self.log.info,
-                data_callback=result_hash.update
+                data_callback=result_hash.update,
+                progress_callback=progress_callback,
             )
             result_size = raw_output_obj.tell()
             raw_output_obj.seek(0)


### PR DESCRIPTION
If rohmu version 1.0.10 or greater is installed,
`pghoard.basebackup_bytes_uploaded` will correctly report the number of bytes uploaded during basebackup generation.

If an earlier version of rohmu is used, the metric will still be generated, but its value will be small (but nonzero). This may still be useful to indicate that a basebackup is in progress.