### PR TITLE
Collect upload metrics during additional basebackup phase

### DIFF
--- a/pghoard/basebackup/base.py
+++ b/pghoard/basebackup/base.py
@@ -316,6 +316,9 @@ class PGBaseBackup(PGHoardThread):
         })
         metadata.update(self.metadata)
 
+        def callback(n_bytes:int) -> None:
+            self.metrics.increase("pghoard.basebackup_bytes_uploaded", inc_value=n_bytes, tags={"delta": False})
+
         self.transfer_queue.put(
             UploadEvent(
                 file_type=FileType.Basebackup,
@@ -323,6 +326,7 @@ class PGBaseBackup(PGHoardThread):
                 file_path=basebackup_path,
                 callback_queue=self.callback_queue,
                 file_size=compressed_file_size,
+                incremental_progress_callback=callback,
                 source_data=stream_target,
                 remove_after_upload=True,
                 metadata=metadata

--- a/pghoard/basebackup/base.py
+++ b/pghoard/basebackup/base.py
@@ -316,7 +316,7 @@ class PGBaseBackup(PGHoardThread):
         })
         metadata.update(self.metadata)
 
-        def callback(n_bytes:int) -> None:
+        def callback(n_bytes: int) -> None:
             self.metrics.increase("pghoard.basebackup_bytes_uploaded", inc_value=n_bytes, tags={"delta": False})
 
         self.transfer_queue.put(

--- a/pghoard/basebackup/chunks.py
+++ b/pghoard/basebackup/chunks.py
@@ -192,6 +192,9 @@ class ChunkUploader:
 
         middle_path, chunk_name = ChunkUploader.chunk_path_to_middle_path_name(Path(chunk_path), file_type)
 
+        def callback(n_bytes:int) -> None:
+            self.metrics.increase("pghoard.basebackup_bytes_uploaded", inc_value=n_bytes, tags={"delta": False})
+
         self.transfer_queue.put(
             UploadEvent(
                 callback_queue=callback_queue,
@@ -200,6 +203,7 @@ class ChunkUploader:
                 file_path=middle_path / chunk_name,
                 source_data=chunk_path,
                 metadata=metadata,
+                incremental_progress_callback=callback,
                 backup_site_name=self.site,
             )
         )

--- a/pghoard/basebackup/chunks.py
+++ b/pghoard/basebackup/chunks.py
@@ -192,7 +192,7 @@ class ChunkUploader:
 
         middle_path, chunk_name = ChunkUploader.chunk_path_to_middle_path_name(Path(chunk_path), file_type)
 
-        def callback(n_bytes:int) -> None:
+        def callback(n_bytes: int) -> None:
             self.metrics.increase("pghoard.basebackup_bytes_uploaded", inc_value=n_bytes, tags={"delta": False})
 
         self.transfer_queue.put(

--- a/pghoard/basebackup/delta.py
+++ b/pghoard/basebackup/delta.py
@@ -188,6 +188,9 @@ class DeltaBaseBackup:
 
         dest_path = Path("basebackup_delta") / result_digest
 
+        def callback(n_bytes:int) -> None:
+            self.metrics.increase("pghoard.basebackup_bytes_uploaded", inc_value=n_bytes, tags={"delta": True})
+
         self.transfer_queue.put(
             UploadEvent(
                 callback_queue=callback_queue,
@@ -196,6 +199,7 @@ class DeltaBaseBackup:
                 backup_site_name=self.site,
                 metadata=metadata,
                 file_path=dest_path,
+                incremental_progress_callback=callback,
                 source_data=chunk_path
             )
         )

--- a/pghoard/basebackup/delta.py
+++ b/pghoard/basebackup/delta.py
@@ -188,7 +188,7 @@ class DeltaBaseBackup:
 
         dest_path = Path("basebackup_delta") / result_digest
 
-        def callback(n_bytes:int) -> None:
+        def callback(n_bytes: int) -> None:
             self.metrics.increase("pghoard.basebackup_bytes_uploaded", inc_value=n_bytes, tags={"delta": True})
 
         self.transfer_queue.put(

--- a/pghoard/transfer.py
+++ b/pghoard/transfer.py
@@ -316,7 +316,7 @@ class TransferAgent(PGHoardThread):
             storage = self.get_object_storage(site)
             unlink_local = file_to_transfer.remove_after_upload
             self.log.info("Uploading file to object store: src=%r dst=%r", file_to_transfer.source_data, key)
-            if isinstance(file_to_transfer.source_data, BinaryIO):
+            if isinstance(file_to_transfer.source_data, (BinaryIO, BytesIO)):
                 f = file_to_transfer.source_data
             else:
                 f = open(file_to_transfer.source_data, "rb")

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,5 @@
 # Use pip for build requirements to harmonize between OS versions
+boto3
 mock
 mypy
 pylint>=2.4.3,<=2.7.2

--- a/test/test_transferagent.py
+++ b/test/test_transferagent.py
@@ -145,7 +145,7 @@ class TestTransferAgent(PGHoardTestCase):
             expected_key,
             ANY,
             metadata={
-                "Content-Length": 3,
+                "Content-Length": "3",
                 "start-wal-segment": "00000001000000000000000C"
             },
             upload_progress_fn=None
@@ -167,10 +167,13 @@ class TestTransferAgent(PGHoardTestCase):
         assert callback_queue.get(timeout=1.0) == CallbackEvent(success=True, payload={"file_size": 3})
         expected_key = "site_specific_prefix/xlog/00000001000000000000000C"
         storage.store_file_object.assert_called_with(
-            expected_key, ANY, metadata={
-                "Content-Length": 3,
+            expected_key,
+            ANY,
+            metadata={
+                "Content-Length": "3",
                 "start-wal-segment": "00000001000000000000000C"
-            }
+            },
+            upload_progress_fn=None
         )
         assert os.path.exists(self.foo_path) is False
 

--- a/test/test_transferagent.py
+++ b/test/test_transferagent.py
@@ -142,10 +142,13 @@ class TestTransferAgent(PGHoardTestCase):
         assert os.path.exists(self.foo_path) is True
         expected_key = os.path.join(self.test_site, "xlog/00000001000000000000000C")
         storage.store_file_object.assert_called_with(
-            expected_key, ANY, metadata={
+            expected_key,
+            ANY,
+            metadata={
                 "Content-Length": 3,
                 "start-wal-segment": "00000001000000000000000C"
-            }
+            },
+            upload_progress_fn=None
         )
         # Now check that the prefix is used.
         self._inject_prefix("site_specific_prefix")


### PR DESCRIPTION

    Where basic, piped or delta basebackup method is selected,
    there is a step where data is being uploaded and the backup is
    not yet available, but no activity is sent to the statsd agent.

    Register an additional callback to collect the number of bytes
    transferred and report it alongside the values from a previous phase.
    This helps avoid unnecessary alerts due to basebackups spending time
    here.
