### PR TITLE
remove pg home dir from promote_trigger_file config

### DIFF
--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -124,7 +124,7 @@ def create_recovery_conf(
     lines = [
         "# pghoard created recovery.conf",
         "recovery_target_timeline = 'latest'",
-        "{} = {}".format(trigger_file_setting, adapt(os.path.join(dirpath, "trigger_file"))),
+        "{} = {}".format(trigger_file_setting, adapt("trigger_file")),
         "restore_command = '{}'".format(" ".join(restore_command)),
     ]
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
Uses relative path of pgdata directory instead of absolute path. Tested with the following steps:

1. Stop master pg service
2. Created trigger_file on standby's pg data directory
3. Double checking if standby was promoted

<!-- Provide the issue number below if it exists. -->
Resolves: #BF-729

# Why this way

This way we don't expose entire structure of the filesystem for pgdata directory

