### PR TITLE
Use correct label when performing chunked basebackup

### DIFF
--- a/pghoard/basebackup/base.py
+++ b/pghoard/basebackup/base.py
@@ -615,6 +615,7 @@ class PGBaseBackup(PGHoardThread):
                         data_file_format,
                         compressed_base,
                         delta_stats=delta_stats,
+                        delta=delta,
                         file_type=FileType.Basebackup_chunk
                     )
 
@@ -724,6 +725,7 @@ class PGBaseBackup(PGHoardThread):
             callback_queue=self.callback_queue,
             chunk_path=Path(data_file_format(0)), # pylint: disable=too-many-format-args
             temp_dir=compressed_base,
+            delta=delta,
             files_to_backup=control_files,
             file_type=FileType.Basebackup,
             extra_metadata={

--- a/pghoard/basebackup/chunks.py
+++ b/pghoard/basebackup/chunks.py
@@ -136,6 +136,7 @@ class ChunkUploader:
         chunk_path,
         files_to_backup,
         callback_queue: CallbackQueue,
+        delta: bool,
         file_type: FileType = FileType.Basebackup_chunk,
         extra_metadata: Optional[Dict[str, Any]] = None,
         delta_stats: Optional[DeltaStats] = None
@@ -193,7 +194,7 @@ class ChunkUploader:
         middle_path, chunk_name = ChunkUploader.chunk_path_to_middle_path_name(Path(chunk_path), file_type)
 
         def callback(n_bytes: int) -> None:
-            self.metrics.increase("pghoard.basebackup_bytes_uploaded", inc_value=n_bytes, tags={"delta": False})
+            self.metrics.increase("pghoard.basebackup_bytes_uploaded", inc_value=n_bytes, tags={"delta": delta})
 
         self.transfer_queue.put(
             UploadEvent(
@@ -219,6 +220,7 @@ class ChunkUploader:
         chunks,
         index: int,
         temp_dir: Path,
+        delta: bool,
         delta_stats: Optional[DeltaStats] = None,
         file_type: FileType = FileType.Basebackup_chunk
     ) -> Dict[str, Any]:
@@ -226,6 +228,7 @@ class ChunkUploader:
         chunk_name, input_size, result_size = self.tar_one_file(
             callback_queue=chunk_callback_queue,
             chunk_path=chunk_path,
+            delta=delta,
             temp_dir=temp_dir,
             files_to_backup=one_chunk_files,
             delta_stats=delta_stats,
@@ -266,6 +269,7 @@ class ChunkUploader:
         chunks,
         data_file_format: Callable[[int], str],
         temp_base_dir: Path,
+        delta: bool,
         delta_stats: Optional[DeltaStats] = None,
         file_type: FileType = FileType.Basebackup_chunk,
         chunks_max_progress: float = 100.0
@@ -302,6 +306,7 @@ class ChunkUploader:
                         chunks=chunks,
                         index=i,
                         temp_dir=temp_base_dir,
+                        delta=delta,
                         delta_stats=delta_stats,
                         file_type=file_type
                     )

--- a/pghoard/basebackup/delta.py
+++ b/pghoard/basebackup/delta.py
@@ -361,6 +361,7 @@ class DeltaBaseBackup:
         chunk_files = self.chunk_uploader.create_and_upload_chunks(
             chunks=delta_chunks,
             data_file_format=self.data_file_format,
+            delta=True,
             temp_base_dir=self.compressed_base,
             file_type=FileType.Basebackup_delta_chunk,
             chunks_max_progress=chunks_max_progress,


### PR DESCRIPTION
Chunked basebackups are used by both delta and non-delta basebackups. Take this into account when allocating a label to the metric used to track the number of bytes uploaded.

The code path of using chunks in delta did not explicitly include ` delta` argument, and also did not pass in `delta_stats`.