### PR TITLE
create OperationEventProgressTracker class for tracking transfer events

### DIFF
--- a/pghoard/basebackup/base.py
+++ b/pghoard/basebackup/base.py
@@ -35,7 +35,7 @@ from pghoard.common import (
     set_subprocess_stdout_and_stderr_nonblocking, terminate_subprocess
 )
 from pghoard.compressor import CompressionEvent
-from pghoard.transfer import UploadEvent, TransferOperation, OperationEventProgressTracker
+from pghoard.transfer import (OperationEventProgressTracker, TransferOperation, UploadEvent)
 
 BASEBACKUP_NAME = "pghoard_base_backup"
 EMPTY_DIRS = [

--- a/pghoard/basebackup/chunks.py
+++ b/pghoard/basebackup/chunks.py
@@ -23,7 +23,7 @@ from pghoard.common import (
     FileTypePrefixes, NoException
 )
 from pghoard.metrics import Metrics
-from pghoard.transfer import TransferQueue, UploadEvent, TransferOperation, OperationEventProgressTracker
+from pghoard.transfer import (OperationEventProgressTracker, TransferOperation, TransferQueue, UploadEvent)
 
 
 class HashFile:

--- a/pghoard/basebackup/delta.py
+++ b/pghoard/basebackup/delta.py
@@ -30,7 +30,7 @@ from pghoard.common import (
     download_backup_meta_file, extract_pghoard_delta_metadata
 )
 from pghoard.metrics import Metrics
-from pghoard.transfer import TransferQueue, UploadEvent, TransferOperation, OperationEventProgressTracker
+from pghoard.transfer import (OperationEventProgressTracker, TransferOperation, TransferQueue, UploadEvent)
 
 
 @dataclass

--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -28,7 +28,7 @@ from pghoard.common import (
     CallbackEvent, CallbackQueue, FileType, FileTypePrefixes, PGHoardThread, QuitEvent, StrEnum, write_json_file
 )
 from pghoard.metrics import Metrics
-from pghoard.transfer import TransferQueue, UploadEvent, OperationEventProgressTracker, TransferOperation
+from pghoard.transfer import (OperationEventProgressTracker, TransferOperation, TransferQueue, UploadEvent)
 
 
 @enum.unique

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -45,7 +45,7 @@ from pghoard.preservation_request import (
     is_basebackup_preserved, parse_preservation_requests, patch_basebackup_metadata_with_preservation
 )
 from pghoard.receivexlog import PGReceiveXLog
-from pghoard.transfer import TransferAgent, TransferQueue, UploadEvent, OperationEventProgressTracker, TransferOperation
+from pghoard.transfer import (OperationEventProgressTracker, TransferAgent, TransferOperation, TransferQueue, UploadEvent)
 from pghoard.walreceiver import WALReceiver
 from pghoard.webserver import WebServer
 

--- a/test/test_operation_event_progress_tracker.py
+++ b/test/test_operation_event_progress_tracker.py
@@ -1,4 +1,5 @@
 import time
+from typing import Iterator
 from unittest.mock import patch
 
 import pytest
@@ -11,9 +12,7 @@ from pghoard.transfer import OperationEventProgressTracker, TransferOperation
 DEFAULT_WAL_FILE_SIZE = 16_000_000
 
 
-def _wait_for_progress_tracker_to_complete(
-    progress_tracker: OperationEventProgressTracker, timeout: int
-) -> None:
+def _wait_for_progress_tracker_to_stop(progress_tracker: OperationEventProgressTracker, timeout: int) -> None:
     start = time.monotonic()
     while True:
         if progress_tracker.running is False:
@@ -25,17 +24,54 @@ def _wait_for_progress_tracker_to_complete(
         time.sleep(0.1)
 
 
-@patch.object(OperationEventProgressTracker, "WARNING_TIMEOUT", 1)
-@patch.object(OperationEventProgressTracker, "CHECK_FREQUENCY", 0.1)
-def test_progress_tracker_inactivity_warning(caplog: LogCaptureFixture) -> None:
-    progress_tracker = OperationEventProgressTracker(
-        metrics=Metrics(statsd={}),
-        metric_name="pghoard_test",
-        operation=TransferOperation.Upload,
-        file_size=DEFAULT_WAL_FILE_SIZE,
-        tags=None,
-    )
+def _check_for_timeout_warnings(caplog: LogCaptureFixture) -> None:
+    warning_num = 0
+    for record in caplog.records:
+        if record.name == "OperationEventProgressTracker":
+            warning_num += 1
+            assert "Transfer upload operation has been inactive" in record.message
 
+    assert warning_num > 0, "No warnings for inactivity were raised. "
+
+
+@pytest.fixture(name="progress_tracker")
+def fixture_progress_tracker() -> Iterator[OperationEventProgressTracker]:
+    with (
+        patch.object(OperationEventProgressTracker, "WARNING_TIMEOUT", 1),
+        patch.object(OperationEventProgressTracker, "CHECK_FREQUENCY", 0.1),
+    ):
+        progress_tracker = OperationEventProgressTracker(
+            metrics=Metrics(statsd={}),
+            metric_name="pghoard_test",
+            operation=TransferOperation.Upload,
+            file_size=DEFAULT_WAL_FILE_SIZE,
+            tags=None,
+        )
+        yield progress_tracker
+        # make sure not to leave any running thread
+        progress_tracker.stop()
+
+
+def test_progress_tracker_inactivity_no_increments(
+    progress_tracker: OperationEventProgressTracker,
+    caplog: LogCaptureFixture,
+) -> None:
+    caplog.clear()
+    progress_tracker.start()
+
+    # sleep for a bit more than the WARNING_TIMEOUT
+    time.sleep(progress_tracker.WARNING_TIMEOUT + .5)
+    _check_for_timeout_warnings(caplog)
+
+    assert progress_tracker.transfer_operation_is_completed() is False
+    assert progress_tracker.running is True
+
+
+def test_progress_tracker_inactivity_warning_based_on_average(
+    progress_tracker: OperationEventProgressTracker,
+    caplog: LogCaptureFixture,
+) -> None:
+    caplog.clear()
     progress_tracker.start()
 
     # assume the WAL file is uploaded into 4 equal size chunks
@@ -46,12 +82,7 @@ def test_progress_tracker_inactivity_warning(caplog: LogCaptureFixture) -> None:
         time.sleep(increment_wait_times[chunk_idx])
         progress_tracker.increment(n_bytes=chunk_size)
 
-    _wait_for_progress_tracker_to_complete(progress_tracker=progress_tracker, timeout=5)
+    _wait_for_progress_tracker_to_stop(progress_tracker=progress_tracker, timeout=5)
+    _check_for_timeout_warnings(caplog)
 
-    warning_num = 0
-    for record in caplog.records:
-        if record.name == "OperationEventProgressTracker":
-            warning_num += 1
-            assert "Transfer upload operation has been inactive" in record.message
-
-    assert warning_num > 0, "No warnings for inactivity were raised. "
+    assert progress_tracker.transfer_operation_is_completed() is True

--- a/test/test_operation_event_progress_tracker.py
+++ b/test/test_operation_event_progress_tracker.py
@@ -1,0 +1,57 @@
+import time
+from unittest.mock import patch
+
+import pytest
+from _pytest.logging import LogCaptureFixture
+
+from pghoard.metrics import Metrics
+from pghoard.transfer import OperationEventProgressTracker, TransferOperation
+
+# 16 MB
+DEFAULT_WAL_FILE_SIZE = 16_000_000
+
+
+def _wait_for_progress_tracker_to_complete(
+    progress_tracker: OperationEventProgressTracker, timeout: int
+) -> None:
+    start = time.monotonic()
+    while True:
+        if progress_tracker.running is False:
+            break
+
+        if time.monotonic() - start >= timeout:
+            assert progress_tracker.running is True, "Transfer operation has not been completed."
+
+        time.sleep(0.1)
+
+
+@patch.object(OperationEventProgressTracker, "WARNING_TIMEOUT", 1)
+@patch.object(OperationEventProgressTracker, "CHECK_FREQUENCY", 0.1)
+def test_progress_tracker_inactivity_warning(caplog: LogCaptureFixture) -> None:
+    progress_tracker = OperationEventProgressTracker(
+        metrics=Metrics(statsd={}),
+        metric_name="pghoard_test",
+        operation=TransferOperation.Upload,
+        file_size=DEFAULT_WAL_FILE_SIZE,
+        tags=None,
+    )
+
+    progress_tracker.start()
+
+    # assume the WAL file is uploaded into 4 equal size chunks
+    chunk_size = DEFAULT_WAL_FILE_SIZE / 4
+    increment_wait_times = [0.2, 0.2, 2, 0.2]
+
+    for chunk_idx in range(4):
+        time.sleep(increment_wait_times[chunk_idx])
+        progress_tracker.increment(n_bytes=chunk_size)
+
+    _wait_for_progress_tracker_to_complete(progress_tracker=progress_tracker, timeout=5)
+
+    warning_num = 0
+    for record in caplog.records:
+        if record.name == "OperationEventProgressTracker":
+            warning_num += 1
+            assert "Transfer upload operation has been inactive" in record.message
+
+    assert warning_num > 0, "No warnings for inactivity were raised. "


### PR DESCRIPTION
track upload events with OperationEventProgressTracker, raise warning in case it gets stuck during uploads

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

This change introduces `OperationEventProgressTracker`, which is a thread in charge of sending/updating transfer operation metrics and keeping track of all the progress updates sent by rohmu. 

The tracker will monitor the increments (updates) and will log warnings in case the operation seems to be inactive for a certain period of time (based on average of all idle times between increments). 

<!-- Provide the issue number below if it exists. -->
Resolves: #BF-1797

# Why this way
Main issue is that sometimes pghoard might get stuck when uploading WAL/timeline files to the object storage, but we are currently not sure why this happens. So, for making investigation a bit more easier, logging the cases where this happens might be a good start.

After having a better idea of the actual issue, we can add a callback to the tracker that "unstucks" the agent based on the case that we identify
