### PR TITLE
Fix delta basebackup issue when delta file gets truncated [BF-2146]

### DIFF
--- a/pghoard/basebackup/delta.py
+++ b/pghoard/basebackup/delta.py
@@ -43,6 +43,8 @@ class UploadedFilesMetric:
 FilesChunk = Set[Tuple]
 SnapshotFiles = Dict[str, SnapshotFile]
 
+EMPTY_FILE_HASH = hashlib.blake2s().hexdigest()
+
 
 class DeltaBaseBackup:
     def __init__(
@@ -383,7 +385,7 @@ class DeltaBaseBackup:
 
             if snapshot_file.hexdigest:
                 # Patch existing files with stored_file_size from existing manifest files (we can not have it otherwise)
-                if not snapshot_file.stored_file_size:
+                if snapshot_file.stored_file_size == 0 and snapshot_file.hexdigest != EMPTY_FILE_HASH:
                     snapshot_file.stored_file_size = self.tracked_snapshot_files[snapshot_file.hexdigest].stored_file_size
                 digests_metric.count += 1
                 digests_metric.input_size += snapshot_file.file_size

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -489,6 +489,7 @@ def fixture_archive_cleaner(tmp_path):
     archive_cleanup.set_config(config_path, "example-site")
 
     bb_metadata = {
+        "_hash": "abc",
         "backup-decision-time": "2022-03-23T14:57:55.883514+00:00",
         "backup-reason": "scheduled",
         "start-time": "2022-03-23T15:57:55+01:00",
@@ -498,7 +499,7 @@ def fixture_archive_cleaner(tmp_path):
         "compression-algorithm": "snappy",
         "compression-level": "0",
         "original-file-size": "25933312",
-        "host": "toolbox"
+        "host": "toolbox",
     }
     bb_path = tmp_path / "backups" / "example-site" / "basebackup"
     bb_path.mkdir(parents=True)
@@ -506,6 +507,7 @@ def fixture_archive_cleaner(tmp_path):
     (bb_path / "2022-03-23_14-57_0.metadata").write_text(json.dumps(bb_metadata, indent=4))
 
     xlog_metadata = {
+        "_hash": "abc",
         "pg-version": "130006",
         "compression-algorithm": "snappy",
         "compression-level": "0",

--- a/test/data/basebackup/chunks/00000001.pghoard.metadata
+++ b/test/data/basebackup/chunks/00000001.pghoard.metadata
@@ -1,1 +1,1 @@
-{"compression-algorithm": "snappy", "encryption-key-id": "5ba999de817c49a682ffed124abf9a2e", "format": "pghoard-bb-v2", "original-file-size": "20480"}
+{"_hash": "abc", "compression-algorithm": "snappy", "encryption-key-id": "5ba999de817c49a682ffed124abf9a2e", "format": "pghoard-bb-v2", "original-file-size": "20480"}

--- a/test/data/basebackup/chunks/00000002.pghoard.metadata
+++ b/test/data/basebackup/chunks/00000002.pghoard.metadata
@@ -1,1 +1,1 @@
-{"compression-algorithm": "snappy", "encryption-key-id": "5ba999de817c49a682ffed124abf9a2e", "format": "pghoard-bb-v2", "original-file-size": "20480"}
+{"_hash": "abc", "compression-algorithm": "snappy", "encryption-key-id": "5ba999de817c49a682ffed124abf9a2e", "format": "pghoard-bb-v2", "original-file-size": "20480"}

--- a/test/data/basebackup/chunks/00000003.pghoard.metadata
+++ b/test/data/basebackup/chunks/00000003.pghoard.metadata
@@ -1,1 +1,1 @@
-{"compression-algorithm": "snappy", "encryption-key-id": "5ba999de817c49a682ffed124abf9a2e", "format": "pghoard-bb-v2", "original-file-size": "10240"}
+{"_hash": "abc", "compression-algorithm": "snappy", "encryption-key-id": "5ba999de817c49a682ffed124abf9a2e", "format": "pghoard-bb-v2", "original-file-size": "10240"}

--- a/test/data/basebackup/chunks/00000004.pghoard.metadata
+++ b/test/data/basebackup/chunks/00000004.pghoard.metadata
@@ -1,1 +1,1 @@
-{"compression-algorithm": "snappy", "encryption-key-id": "5ba999de817c49a682ffed124abf9a2e", "format": "pghoard-bb-v2", "original-file-size": "20480"}
+{"_hash": "abc", "compression-algorithm": "snappy", "encryption-key-id": "5ba999de817c49a682ffed124abf9a2e", "format": "pghoard-bb-v2", "original-file-size": "20480"}

--- a/test/data/basebackup_delta/chunks/0af668268d0fe14c6e269760b08d80a634c421b8381df25f31fbed5e8a8c8d8b.metadata
+++ b/test/data/basebackup_delta/chunks/0af668268d0fe14c6e269760b08d80a634c421b8381df25f31fbed5e8a8c8d8b.metadata
@@ -1,1 +1,1 @@
-{"compression-algorithm": "snappy", "format": "pghoard-delta-v1", "original-file-size": "16384"}
+{"_hash": "abc", "compression-algorithm": "snappy", "format": "pghoard-delta-v1", "original-file-size": "16384"}

--- a/test/data/basebackup_delta/chunks/4b65df4d0857bbbcb22aa086e02bd8414a9f3a484869f2b96ed7c62f3c4eb088.metadata
+++ b/test/data/basebackup_delta/chunks/4b65df4d0857bbbcb22aa086e02bd8414a9f3a484869f2b96ed7c62f3c4eb088.metadata
@@ -1,1 +1,1 @@
-{"compression-algorithm": "snappy", "format": "pghoard-delta-v1", "original-file-size": "8192"}
+{"_hash": "abc", "compression-algorithm": "snappy", "format": "pghoard-delta-v1", "original-file-size": "8192"}

--- a/test/data/basebackup_delta/chunks/fc61c91430dcb345001306ad513f103380c16896093a17868fc909aeda393559.metadata
+++ b/test/data/basebackup_delta/chunks/fc61c91430dcb345001306ad513f103380c16896093a17868fc909aeda393559.metadata
@@ -1,1 +1,1 @@
-{"compression-algorithm": "snappy", "format": "pghoard-delta-v1", "original-file-size": "24576"}
+{"_hash": "abc", "compression-algorithm": "snappy", "format": "pghoard-delta-v1", "original-file-size": "24576"}

--- a/test/data/basebackup_one_chunk/chunks/00000002.pghoard.metadata
+++ b/test/data/basebackup_one_chunk/chunks/00000002.pghoard.metadata
@@ -1,1 +1,1 @@
-{"compression-algorithm": "snappy", "encryption-key-id": "5ba999de817c49a682ffed124abf9a2e", "format": "pghoard-bb-v2", "original-file-size": "20480"}
+{"_hash": "abc", "compression-algorithm": "snappy", "encryption-key-id": "5ba999de817c49a682ffed124abf9a2e", "format": "pghoard-bb-v2", "original-file-size": "20480"}

--- a/test/data/basebackup_with_ts/chunks/chunk_2018-04-23_2__2018-04-23_2.00000570.pghoard.metadata
+++ b/test/data/basebackup_with_ts/chunks/chunk_2018-04-23_2__2018-04-23_2.00000570.pghoard.metadata
@@ -1,1 +1,1 @@
-{"compression-algorithm": "snappy", "encryption-key-id": "517ba091076547cfaba7d4655b7254c8", "format": "pghoard-bb-v2", "original-file-size": "20480"}
+{"_hash": "abc", "compression-algorithm": "snappy", "encryption-key-id": "517ba091076547cfaba7d4655b7254c8", "format": "pghoard-bb-v2", "original-file-size": "20480"}

--- a/test/data/basebackup_with_ts/chunks/chunk_2018-04-23_2__2018-04-23_2.00000572.pghoard.metadata
+++ b/test/data/basebackup_with_ts/chunks/chunk_2018-04-23_2__2018-04-23_2.00000572.pghoard.metadata
@@ -1,1 +1,1 @@
-{"compression-algorithm": "snappy", "encryption-key-id": "517ba091076547cfaba7d4655b7254c8", "format": "pghoard-bb-v2", "original-file-size": "30720"}
+{"_hash": "abc", "compression-algorithm": "snappy", "encryption-key-id": "517ba091076547cfaba7d4655b7254c8", "format": "pghoard-bb-v2", "original-file-size": "30720"}

--- a/test/data/basebackup_with_ts/chunks/chunk_2018-04-23_2__2018-04-23_2.00000573.pghoard.metadata
+++ b/test/data/basebackup_with_ts/chunks/chunk_2018-04-23_2__2018-04-23_2.00000573.pghoard.metadata
@@ -1,1 +1,1 @@
-{"compression-algorithm": "snappy", "encryption-key-id": "517ba091076547cfaba7d4655b7254c8", "format": "pghoard-bb-v2", "original-file-size": "10240"}
+{"_hash": "abc", "compression-algorithm": "snappy", "encryption-key-id": "517ba091076547cfaba7d4655b7254c8", "format": "pghoard-bb-v2", "original-file-size": "10240"}

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -85,7 +85,7 @@ dbname|"""
         with open(bb_path, "wb") as fp:
             fp.write(b"something")
         with open(metadata_file_path, "w") as fp:
-            json.dump({"start-time": "2015-07-03 12:00:00+00:00"}, fp)
+            json.dump({"_hash": "abc", "start-time": "2015-07-03 12:00:00+00:00"}, fp)
         available_backup = self.pghoard.get_remote_basebackups_info(self.test_site)[0]
         assert available_backup["name"] == "2015-07-03_0"
         start_time = datetime.datetime(2015, 7, 3, 12, tzinfo=datetime.timezone.utc)
@@ -99,7 +99,7 @@ dbname|"""
         with open(bb_path, "wb") as fp:
             fp.write(b"something")
         with open(metadata_file_path, "w") as fp:
-            json.dump({"start-time": "2015-07-02 12:00:00+00:00"}, fp)
+            json.dump({"_hash": "abc", "start-time": "2015-07-02 12:00:00+00:00"}, fp)
         basebackups = self.pghoard.get_remote_basebackups_info(self.test_site)
         assert basebackups[0]["name"] == "2015-07-02_9"
         assert basebackups[1]["name"] == "2015-07-03_0"
@@ -109,7 +109,7 @@ dbname|"""
         with open(bb_path, "wb") as fp:
             fp.write(b"something")
         with open(metadata_file_path, "w") as fp:
-            json.dump({"start-time": "2015-07-02 22:00:00+00"}, fp)
+            json.dump({"_hash": "abc", "start-time": "2015-07-02 22:00:00+00"}, fp)
         basebackups = self.pghoard.get_remote_basebackups_info(self.test_site)
         assert basebackups[0]["name"] == "2015-07-02_9"
         assert basebackups[1]["name"] == "2015-07-02_10"
@@ -357,6 +357,7 @@ dbname|"""
                         fp.write(b"something")
                     with open(bb_path + ".metadata", "w") as fp:
                         json.dump({
+                            "_hash": "abc",
                             "start-wal-segment": wals[0],
                             "start-time": start_time.isoformat(),
                         }, fp)
@@ -475,6 +476,7 @@ dbname|"""
 
                     with open(bb_path + ".metadata", "w") as fp:
                         json.dump({
+                            "_hash": "abc",
                             "start-wal-segment": wal_start,
                             "start-time": start_time.isoformat(),
                             "format": BaseBackupFormat.delta_v2,


### PR DESCRIPTION
This fixes an issue when delta backup fails during backup with the following error:
```
File "/usr/lib/python3.11/site-packages/pghoard/basebackup/delta.py", line 386, in _read_delta_sizes
     snapshot_file.stored_file_size = self.tracked_snapshot_files[snapshot_file.hexdigest].stored_file_size
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: '69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9'
```
The reason for that is when the uploaded delta file gets truncated during upload, its stored file size is a defalt value of 0, in this case the code assumes that this file was uploaded before and size info needs to be taken from the dict of already uploaded files, which is wrong. Here we just skip override of this attribute for empty delta files.