### PR TITLE
verify uncompressed file does not exists under /xlog and /timeline [BF-1358]

### DIFF
--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -637,14 +637,15 @@ class PGHoard:
                         os.unlink(full_path)
                     else:
                         delete_request = WalFileDeletionEvent(backup_site_name=site, file_path=Path(full_path))
+                        self.log.info("Adding an Uncompressed WAL file to deletion queue: %s", full_path)
                         self.wal_file_deletion_queue.put(delete_request)
-                        self.log.info("Adding to Uncompressed WAL file to deletion queue: %s", full_path)
                     continue
 
                 # delete compressed file and re-try
                 if is_already_compressed and not has_metadata_file:
                     self.log.info(
-                        "Deleting invalid compressed file %r, compression will be re-tried", compressed_file_path,
+                        "Deleting incomplete compressed file %r (missing metadata), compression will be re-tried",
+                        compressed_file_path,
                     )
                     os.unlink(compressed_file_path)
 

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -626,7 +626,12 @@ class PGHoard:
                 base_compressed_file_path = (
                     compressed_timeline_path if filetype is FileType.Timeline else compressed_xlog_path
                 )
-                if os.path.isfile(os.path.join(base_compressed_file_path, filename)):
+                compressed_file_path = os.path.join(base_compressed_file_path, filename)
+                is_already_compressed = os.path.exists(compressed_file_path)
+                has_metadata_file = os.path.exists(compressed_file_path + ".metadata")
+
+                # the file was compressed correctly
+                if is_already_compressed and has_metadata_file:
                     self.log.debug("Uncompressed file %r is already compressed, adding to deletion queue.", full_path)
                     if filetype is FileType.Timeline:
                         os.unlink(full_path)
@@ -635,6 +640,13 @@ class PGHoard:
                         self.wal_file_deletion_queue.put(delete_request)
                         self.log.info("Adding to Uncompressed WAL file to deletion queue: %s", full_path)
                     continue
+
+                # delete compressed file and re-try
+                if is_already_compressed and not has_metadata_file:
+                    self.log.info(
+                        "Deleting invalid compressed file %r, compression will be re-tried", compressed_file_path,
+                    )
+                    os.unlink(compressed_file_path)
 
                 compression_event = CompressionEvent(
                     file_type=filetype,

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from queue import Empty, Queue
 from threading import Event
-from typing import Dict, List, Optional
+from typing import Dict, List, NamedTuple, Optional
 
 import psycopg2
 from rohmu import dates, get_transfer, rohmufile
@@ -39,7 +39,7 @@ from pghoard.common import (
     replication_connection_string_and_slot_using_pgpass, write_json_file
 )
 from pghoard.compressor import (
-    CompressionEvent, CompressionQueue, CompressorThread, WALFileDeleterThread, WalFileDeletionQueue
+    CompressionEvent, CompressionQueue, CompressorThread, WALFileDeleterThread, WalFileDeletionEvent, WalFileDeletionQueue
 )
 from pghoard.preservation_request import (
     is_basebackup_preserved, parse_preservation_requests, patch_basebackup_metadata_with_preservation
@@ -54,6 +54,14 @@ from pghoard.webserver import WebServer
 class DeltaBaseBackupFailureInfo:
     last_failed_time: datetime.datetime
     retries: int = 0
+
+
+class BackupSitePaths(NamedTuple):
+    compressed_xlog_path: str
+    compressed_timeline_path: str
+    uncompressed_files_path: str
+    basebackup_path: str
+    uncompressed_basebackup_path: str
 
 
 class InotifyAdapter:
@@ -287,24 +295,25 @@ class PGHoard:
     def _get_site_prefix(self, site):
         return self.config["backup_sites"][site]["prefix"]
 
-    def create_backup_site_paths(self, site):
+    def create_backup_site_paths(self, site: str) -> BackupSitePaths:
         site_path = os.path.join(self.config["backup_location"], self._get_site_prefix(site))
         xlog_path = os.path.join(site_path, "xlog")
+        timeline_path = os.path.join(site_path, "timeline")
         basebackup_path = os.path.join(site_path, "basebackup")
 
-        paths_to_create = [
-            site_path,
-            xlog_path,
-            xlog_path + "_incoming",
-            basebackup_path,
-            basebackup_path + "_incoming",
-        ]
+        backup_site_paths = BackupSitePaths(
+            uncompressed_files_path=xlog_path + "_incoming",
+            compressed_xlog_path=xlog_path,
+            compressed_timeline_path=timeline_path,
+            basebackup_path=basebackup_path,
+            uncompressed_basebackup_path=basebackup_path + "_incoming",
+        )
 
-        for path in paths_to_create:
+        for path in backup_site_paths:
             if not os.path.exists(path):
                 os.makedirs(path)
 
-        return xlog_path, basebackup_path
+        return backup_site_paths
 
     def delete_remote_wal_before(self, wal_segment, site, pg_version):
         self.log.info("Starting WAL deletion from: %r before: %r, pg_version: %r", site, wal_segment, pg_version)
@@ -577,12 +586,15 @@ class PGHoard:
         """Check xlog and xlog_incoming directories for files that receivexlog has received but not yet
         compressed as well as the files we have compressed but not yet uploaded and process them."""
         for site in self.config["backup_sites"]:
-            compressed_xlog_path, _ = self.create_backup_site_paths(site)
-            uncompressed_xlog_path = compressed_xlog_path + "_incoming"
+            backup_site_paths = self.create_backup_site_paths(site)
+
+            compressed_xlog_path = backup_site_paths.compressed_xlog_path
+            compressed_timeline_path = backup_site_paths.compressed_timeline_path
+            uncompressed_files_path = backup_site_paths.uncompressed_files_path
 
             # Process uncompressed files (ie WAL pg_receivexlog received)
-            for filename in os.listdir(uncompressed_xlog_path):
-                full_path = os.path.join(uncompressed_xlog_path, filename)
+            for filename in os.listdir(uncompressed_files_path):
+                full_path = os.path.join(uncompressed_files_path, filename)
                 if wal.PARTIAL_WAL_RE.match(filename):
                     # pg_receivewal may have been in the middle of storing WAL file when PGHoard was stopped.
                     # If the file is 0 or 16 MiB in size it will continue normally but in some cases the file can be
@@ -608,6 +620,21 @@ class PGHoard:
                     continue
 
                 filetype = FileType.Timeline if wal.TIMELINE_RE.match(filename) else FileType.Wal
+
+                # verify if file was already compressed, otherwise the transfer agent will encounter
+                # duplicated UploadEvents. In case it was compressed, we should just add it to the deletion queue
+                base_compressed_file_path = (
+                    compressed_timeline_path if filetype is FileType.Timeline else compressed_xlog_path
+                )
+                if os.path.isfile(os.path.join(base_compressed_file_path, filename)):
+                    self.log.debug("Uncompressed file %r is already compressed, adding to deletion queue.", full_path)
+                    if filetype is FileType.Timeline:
+                        os.unlink(full_path)
+                    else:
+                        delete_request = WalFileDeletionEvent(backup_site_name=site, file_path=Path(full_path))
+                        self.wal_file_deletion_queue.put(delete_request)
+                        self.log.info("Adding to Uncompressed WAL file to deletion queue: %s", full_path)
+                    continue
 
                 compression_event = CompressionEvent(
                     file_type=filetype,
@@ -668,7 +695,7 @@ class PGHoard:
 
     def handle_site(self, site, site_config):
         self.set_state_defaults(site)
-        xlog_path, basebackup_path = self.create_backup_site_paths(site)
+        backup_site_paths = self.create_backup_site_paths(site)
 
         if not site_config["active"]:
             return  # If a site has been marked inactive, don't bother checking anything
@@ -679,7 +706,7 @@ class PGHoard:
 
         if site not in self.receivexlogs and site not in self.walreceivers:
             if site_config["active_backup_mode"] == "pg_receivexlog":
-                self.receivexlog_listener(site, chosen_backup_node, xlog_path + "_incoming")
+                self.receivexlog_listener(site, chosen_backup_node, backup_site_paths.uncompressed_files_path)
             elif site_config["active_backup_mode"] == "walreceiver":
                 state_file_path = self.config["json_state_file_path"]
                 walreceiver_state = {}
@@ -745,7 +772,13 @@ class PGHoard:
                         return
 
             self.basebackups_callbacks[site] = Queue()
-            self.create_basebackup(site, chosen_backup_node, basebackup_path, self.basebackups_callbacks[site], metadata)
+            self.create_basebackup(
+                site=site,
+                connection_info=chosen_backup_node,
+                basebackup_path=backup_site_paths.basebackup_path,
+                callback_queue=self.basebackups_callbacks[site],
+                metadata=metadata,
+            )
 
     def get_new_backup_details(self, *, now=None, site, site_config):
         """Returns metadata to associate with new backup that needs to be created or None in case no backup should

--- a/test/test_compressor.py
+++ b/test/test_compressor.py
@@ -176,6 +176,13 @@ class CompressionCase(PGHoardTestCase):
                 assert transfer_event.metadata.pop("hash-algorithm") == "sha1"
             assert getattr(transfer_event, key) == value
 
+        compressed_file_path = os.path.join(
+            self.config["backup_location"], self.config["backup_sites"][self.test_site]["prefix"],
+            "xlog" if filetype == "xlog" else "timeline", file_path.name
+        )
+        # make sure the file was compressed on the expected location
+        assert os.path.exists(compressed_file_path)
+
     def test_compress_to_memory(self):
         ifile = WALTester(self.incoming_path, "0000000100000000000000FF", "random")
         filetype = FileType.Wal

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -806,8 +806,12 @@ dbname|"""
 
         # only one file should be added for compression (invalid compressed one)
         assert self.pghoard.compression_queue.qsize() == 1
+        compression_event = self.pghoard.compression_queue.get()
+        assert compression_event.file_path.name == invalid_compressed_file_name
 
         assert self.pghoard.transfer_queue.qsize() == 1
+        upload_event = self.pghoard.transfer_queue.get()
+        assert upload_event.file_path.name == file_name
 
         if file_type is FileType.Wal:
             assert self.pghoard.wal_file_deletion_queue.qsize() == 1

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -696,26 +696,28 @@ dbname|"""
         assert empty_state == state
 
     def test_startup_walk_for_missed_compressed_files(self):
-        compressed_wal_path, _ = self.pghoard.create_backup_site_paths(self.test_site)
-        with open(os.path.join(compressed_wal_path, "000000010000000000000004"), "wb") as fp:
+        backup_site_paths = self.pghoard.create_backup_site_paths(self.test_site)
+        with open(os.path.join(backup_site_paths.compressed_xlog_path, "000000010000000000000004"), "wb") as fp:
             fp.write(b"foo")
-        with open(os.path.join(compressed_wal_path, "000000010000000000000004.metadata"), "wb") as fp:
+        with open(os.path.join(backup_site_paths.compressed_xlog_path, "000000010000000000000004.metadata"), "wb") as fp:
             fp.write(b"{}")
-        with open(os.path.join(compressed_wal_path, "0000000F.history"), "wb") as fp:
+        with open(os.path.join(backup_site_paths.compressed_timeline_path, "0000000F.history"), "wb") as fp:
             fp.write(b"foo")
-        with open(os.path.join(compressed_wal_path, "0000000F.history.metadata"), "wb") as fp:
+        with open(os.path.join(backup_site_paths.compressed_timeline_path, "0000000F.history.metadata"), "wb") as fp:
             fp.write(b"{}")
-        with open(os.path.join(compressed_wal_path, "000000010000000000000004xyz"), "wb") as fp:
+        with open(os.path.join(backup_site_paths.compressed_xlog_path, "000000010000000000000004xyz"), "wb") as fp:
             fp.write(b"foo")
-        with open(os.path.join(compressed_wal_path, "000000010000000000000004xyz.metadata"), "wb") as fp:
+        with open(os.path.join(backup_site_paths.compressed_xlog_path, "000000010000000000000004xyz.metadata"), "wb") as fp:
             fp.write(b"{}")
         self.pghoard.startup_walk_for_missed_files()
         assert self.pghoard.compression_queue.qsize() == 0
         assert self.pghoard.transfer_queue.qsize() == 2
 
     def test_startup_walk_for_missed_uncompressed_files(self):
-        compressed_wal_path, _ = self.pghoard.create_backup_site_paths(self.test_site)
-        uncompressed_wal_path = compressed_wal_path + "_incoming"
+        backup_site_paths = self.pghoard.create_backup_site_paths(self.test_site)
+
+        uncompressed_wal_path = backup_site_paths.uncompressed_files_path
+
         with open(os.path.join(uncompressed_wal_path, "000000010000000000000004"), "wb") as fp:
             fp.write(b"foo")
         with open(os.path.join(uncompressed_wal_path, "00000002.history"), "wb") as fp:
@@ -730,9 +732,8 @@ dbname|"""
         "file_type, file_name", [(FileType.Wal, "000000010000000000000004"), (FileType.Timeline, "00000002.history")]
     )
     def test_startup_walk_for_missed_uncompressed_file_type(self, file_type: FileType, file_name: str):
-        compressed_wal_path, _ = self.pghoard.create_backup_site_paths(self.test_site)
-        uncompressed_wal_path = compressed_wal_path + "_incoming"
-        with open(os.path.join(uncompressed_wal_path, file_name), "wb") as fp:
+        backup_site_paths = self.pghoard.create_backup_site_paths(self.test_site)
+        with open(os.path.join(backup_site_paths.uncompressed_files_path, file_name), "wb") as fp:
             fp.write(b"foo")
         self.pghoard.startup_walk_for_missed_files()
         assert self.pghoard.compression_queue.qsize() == 1
@@ -744,16 +745,75 @@ dbname|"""
         "file_type, file_name", [(FileType.Wal, "000000010000000000000005"), (FileType.Timeline, "00000003.history")]
     )
     def test_startup_walk_for_missed_compressed_file_type(self, file_type: FileType, file_name: str):
-        compressed_wal_path, _ = self.pghoard.create_backup_site_paths(self.test_site)
-        with open(os.path.join(compressed_wal_path, file_name), "wb") as fp:
+        backup_site_paths = self.pghoard.create_backup_site_paths(self.test_site)
+
+        if file_type is FileType.Wal:
+            compressed_file_path = backup_site_paths.compressed_xlog_path
+        else:
+            compressed_file_path = backup_site_paths.compressed_timeline_path
+
+        with open(os.path.join(compressed_file_path, file_name), "wb") as fp:
             fp.write(b"foo")
-        with open(os.path.join(compressed_wal_path, f"{file_name}.metadata"), "wb") as fp:
+        with open(os.path.join(compressed_file_path, f"{file_name}.metadata"), "wb") as fp:
             fp.write(b"{}")
         self.pghoard.startup_walk_for_missed_files()
         assert self.pghoard.compression_queue.qsize() == 0
         assert self.pghoard.transfer_queue.qsize() == 1
         upload_event = self.pghoard.transfer_queue.get(timeout=1.0)
         assert upload_event.file_type == file_type
+
+    @pytest.mark.parametrize(
+        "file_type, file_name, invalid_compressed_file_name", [
+            (FileType.Wal, "000000010000000000000005", "000000010000000000000006"),
+            (FileType.Timeline, "00000003.history", "00000004.history"),
+        ]
+    )
+    def test_startup_walk_skip_compression_if_already_compressed(
+        self,
+        file_type: FileType,
+        file_name: str,
+        invalid_compressed_file_name: str,
+    ) -> None:
+        """
+        Tests the scenario where an uncompressed file was already compressed, but was not deleted.
+        """
+        backup_site_paths = self.pghoard.create_backup_site_paths(self.test_site)
+        uncompressed_wal_path = backup_site_paths.uncompressed_files_path
+        compressed_file_path = (
+            backup_site_paths.compressed_timeline_path
+            if file_type is FileType.Timeline else backup_site_paths.compressed_xlog_path
+        )
+
+        # generate  uncompressed/compressed files
+        with open(os.path.join(uncompressed_wal_path, file_name), "wb") as fp:
+            fp.write(b"random")
+
+        with open(os.path.join(uncompressed_wal_path, invalid_compressed_file_name), "wb") as fp:
+            fp.write(b"random")
+
+        # compressed
+        with open(os.path.join(compressed_file_path, file_name), "wb") as fp:
+            fp.write(b"random")
+
+        with open(os.path.join(compressed_file_path, f"{file_name}.metadata"), "wb") as fp:
+            fp.write(b"{}")
+
+        # invalid compressed file should not have a metadata
+        with open(os.path.join(compressed_file_path, invalid_compressed_file_name), "wb") as fp:
+            fp.write(b"random")
+
+        self.pghoard.startup_walk_for_missed_files()
+
+        # only one file should be added for compression (invalid compressed one)
+        assert self.pghoard.compression_queue.qsize() == 1
+
+        assert self.pghoard.transfer_queue.qsize() == 1
+
+        if file_type is FileType.Wal:
+            assert self.pghoard.wal_file_deletion_queue.qsize() == 1
+        else:
+            # uncompressed timeline files are not added to deletion queue, they are immediately unlinked
+            assert self.pghoard.wal_file_deletion_queue.qsize() == 0
 
 
 class TestPGHoardWithPG:


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
* Skip re-compressing during startup_walk. This happens when restarting pghoard while the deletion queue has not been emptied. Meaning, that pghoard might had already compressed some files but not deleted them yet, which ends up on duplicated upload events.

    For example during startup, WAL file `00001`  exists in both `/xlog` and `/xlog_incoming`, pghoard will attempt to compress all files in `/xlog_incoming` and later upload files in `/xlog`. The transfer agent will end up adding 2 upload events for  `00001` compressed file, but the second event will fail since the compressed file might have been already deleted, so the transfer agent will keep retrying and end up getting stuck.

* Missing uploading compressed timeline files, noticed that during the startup walk, pghoard is only checking files in `xlog` path, but compressed timelines are stored under `/timeline`. 


<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #BF-1358
