### PR TITLE
handle a graceful shutdown on request

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -28,7 +28,7 @@ disable=
 
 [FORMAT]
 max-line-length=125
-max-module-lines=1100
+max-module-lines=1200
 
 [REPORTS]
 output-format=text

--- a/README.rst
+++ b/README.rst
@@ -460,6 +460,15 @@ configuration keys for sites are listed below.
  * ``level`` default ``"0"`` compression level for ``"lzma"`` or ``"zstd"`` compression
  * ``thread_count`` (default max(cpu_count, ``5``)) number of parallel compression threads
 
+``graceful_shutdown_compression_timeout``
+The maximum time, in seconds, the application will wait after receiving a graceful shutdown signal (SIGTERM) for all
+active compression threads to finish compressing the files remaining in the compression queue.
+
+``graceful_shutdown_upload_timeout``
+The maximum time, in seconds, the application will wait after receiving a graceful shutdown signal (SIGTERM) for all
+transfer queues to finish uploading the files remaining in the transfer queue.
+
+
 ``hash_algorithm`` (default ``"sha1"``)
 
 The hash algorithm used for calculating checksums for WAL or other files. Must

--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -43,7 +43,7 @@ class BaseCompressorEvent:
     file_path: Path
     backup_site_name: str
     source_data: Union[BinaryIO, Path]
-    callback_queue: CallbackQueue
+    callback_queue: Optional[CallbackQueue]
     metadata: Dict[str, str]
 
 

--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -89,6 +89,8 @@ def set_and_check_config_defaults(config, *, check_commands=True, check_pgdata=T
     # TODO: consider implementing a real configuration schema at some point
     # misc global defaults
     config.setdefault("backup_location", None)
+    config.setdefault("graceful_shutdown_compression_timeout", 180)  # default 3 minutes
+    config.setdefault("graceful_shutdown_upload_timeout", 300)  # default 5 minutes
     config.setdefault("http_address", PGHOARD_HOST)
     config.setdefault("http_port", PGHOARD_PORT)
     config.setdefault("webserver_username", None)


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
Handles graceful shutdowns by making sure all compressed files get uploaded ~(considers also partial files)~
Edit: renaming partial files is dangerous, after testing I didn't got the expected results (duplicated segments on different timelines)

# Why this way

Shutting down pghoard can be dangerous, leading to missed segments if not all information was uploaded. To avoid this, its better to make sure all tasks/events were completed.



