### PR TITLE
add content-length even if file size is 0

### DIFF
--- a/pghoard/transfer.py
+++ b/pghoard/transfer.py
@@ -323,7 +323,7 @@ class TransferAgent(PGHoardThread):
                 f = open(file_to_transfer.source_data, "rb")
             with f:
                 metadata = file_to_transfer.metadata.copy()
-                if file_to_transfer.file_size:
+                if file_to_transfer.file_size is not None:
                     metadata["Content-Length"] = str(file_to_transfer.file_size)
                 storage.store_file_object(
                     key, f, metadata=metadata, upload_progress_fn=file_to_transfer.incremental_progress_callback


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

pghoard is not adding content-length when file size is 0, currently rohmu will by default try multipart upload for null content-length file objects.

<!-- Provide the issue number below if it exists. -->
Resolves: #BF-2330


