### PR TITLE
monitor pg connection when uploading chunks

### DIFF
--- a/pghoard/pgutil.py
+++ b/pghoard/pgutil.py
@@ -5,8 +5,9 @@ pghoard - postgresql utility functions
 Copyright (c) 2015 Ohmu Ltd
 See LICENSE for details
 """
-
 from urllib.parse import parse_qs, urlparse
+
+from psycopg2.extensions import (TRANSACTION_STATUS_ACTIVE, TRANSACTION_STATUS_IDLE, TRANSACTION_STATUS_INTRANS)
 
 
 def create_connection_string(connection_info):
@@ -92,3 +93,14 @@ def parse_connection_string_libpq(connection_string):
                 value, connection_string = rem, ""
         fields[key] = value
     return fields
+
+
+def check_if_pg_connection_is_alive(db_conn) -> bool:
+    if db_conn.closed:
+        return False
+
+    status = db_conn.get_transaction_status()
+    if status not in [TRANSACTION_STATUS_ACTIVE, TRANSACTION_STATUS_IDLE, TRANSACTION_STATUS_INTRANS]:
+        return False
+
+    return True


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
While creating a backup, both `pg_start_backup` and `pg_stop_backup` must be executed within the same session. However, in some cases, the backup process may take several hours (especially when processing large chunks). During this time, the PostgreSQL instance may experience a restart, causing the connection used for the backup to be lost.

As a result, pghoard may continue uploading chunks, only to encounter a connection error when attempting to finish the backup. This leads to wasted time, as the system attempts to complete the backup and then raises an exception due to the lost connection. The backup will then retry, potentially leading to further delays and redundant work.

So now, instead of letting the backup continue and fail due to a lost connection, each upload task will actively monitor the connection during the process. If the connection is lost, the task will be aborted, raising an exception to indicate that the connection is no longer available.

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #BF-2931

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

