### PR TITLE
Support pg17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
           # Setup build deps
-          sudo apt-get install -y libsnappy-dev postgresql-10 postgresql-11 postgresql-12 postgresql-13 postgresql-14 postgresql-15 postgresql-16
+          sudo apt-get install -y libsnappy-dev postgresql-12 postgresql-13 postgresql-14 postgresql-15 postgresql-16 postgresql-17
           # Setup common python dependencies
           python -m pip install --upgrade pip
           pip install .

--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ python 3.10, 3.11 and 3.12 virtual environments and installations of postgresql 
 By default vagrant up will start a Virtualbox environment. The Vagrantfile will also work for libvirt, just prefix
 ``VAGRANT_DEFAULT_PROVIDER=libvirt`` to the ``vagrant up`` command.
 
-Any combination of Python (3.10, 3.11 and 3.12) and Postgresql (12, 13, 14, 15 and 16)
+Any combination of Python (3.10, 3.11 and 3.12) and Postgresql (12, 13, 14, 15, 16 and 17)
 
 Bring up vagrant instance and connect via ssh::
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ Vagrant.configure("2") do |config|
         sed -i "s/^#create_main_cluster.*/create_main_cluster=false/g" /etc/postgresql-common/createcluster.conf
 
         apt-get install -y python{3.10,3.11,3.12} python{3.10,3.11,3.12}-dev python{3.10,3.11,3.12}-venv
-        apt-get install -y postgresql-{12,13,14,15,16} postgresql-server-dev-{12,13,14,15,16}
+        apt-get install -y postgresql-{12,13,14,15,16,17} postgresql-server-dev-{12,13,14,15,16,17}
 
         username="$(< /dev/urandom tr -dc a-z | head -c${1:-32};echo;)"
         password=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32};echo;)

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -54,12 +54,12 @@ Vagrant
 =======
 
 The Vagrantfile can be used to setup a vagrant development environment.   The vagrant environment has
-python 3.10, 3.11 and 3.12 virtual environments and installations of postgresql 12, 13, 14, 15 and 16.
+python 3.10, 3.11 and 3.12 virtual environments and installations of postgresql 12, 13, 14, 15, 16 and 17.
 
 By default vagrant up will start a Virtualbox environment. The Vagrantfile will also work for libvirt, just prefix
 ``VAGRANT_DEFAULT_PROVIDER=libvirt`` to the ``vagrant up`` command.
 
-Any combination of Python (3.10, 3.11 and 3.12) and Postgresql (12, 13, 14, 15 and 16)
+Any combination of Python (3.10, 3.11 and 3.12) and Postgresql (12, 13, 14, 15, 16 and 17)
 
 Bring up vagrant instance and connect via ssh::
 

--- a/pghoard/config.py
+++ b/pghoard/config.py
@@ -17,7 +17,7 @@ from rohmu.snappyfile import snappy
 from pghoard.common import (extract_pg_command_version_string, pg_major_version, pg_version_string_to_number)
 from pghoard.postgres_command import PGHOARD_HOST, PGHOARD_PORT
 
-SUPPORTED_VERSIONS = ["16", "15", "14", "13", "12", "11", "10", "9.6", "9.5", "9.4", "9.3"]
+SUPPORTED_VERSIONS = ["17", "16", "15", "14", "13", "12", "11", "10", "9.6", "9.5", "9.4", "9.3"]
 
 
 def get_cpu_count():

--- a/pghoard/wal.py
+++ b/pghoard/wal.py
@@ -32,6 +32,7 @@ WAL_MAGIC = {
     0xD10D: 140000,
     0xD110: 150000,
     0xD113: 160000,
+    0xD116: 170000,
 }
 WAL_MAGIC_BY_VERSION = {value: key for key, value in WAL_MAGIC.items()}
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -35,7 +35,7 @@ from pghoard.pghoard import PGHoard
 
 logutil.configure_logging()
 
-DEFAULT_PG_VERSIONS = ["16", "15", "14", "13", "12"]
+DEFAULT_PG_VERSIONS = ["17", "16", "15", "14", "13", "12"]
 
 
 def port_is_listening(hostname: str, port: int, timeout: float = 0.5) -> bool:


### PR DESCRIPTION
# About this change - What it does
Includes necessary changes for supporting  PostgreSQL 17.

This PR updates the behavior of pg_walfile_name based on changes introduced in PostgreSQL 17 (PG17). Instead of calling `(pg_current_lsn), the function now uses the LSN obtained from the result of pg_backup_stop.

# Why this way

For versions earlier than PG17, pg_walfile_name returns the previous WAL file name in certain edge cases, such as when the backup’s ending LSN falls on a segment boundary. This issue was resolved in PG17, making the get_backup_end_segment_and_time function largely obsolete for newer versions. As a result, for PG17 and later, backup end segments now rely directly on the pg_backup_stop result.

**Note on Testing**
While an edge case test was considered (where the backup’s ending LSN falls on a boundary), it was ultimately not included. This test requires a fresh PostgreSQL service to reliably reproduce the scenario. However, in shared pipeline environments, where other tests may have already committed transactions, reproducing the issue is highly inconsistent. Therefore, the test was deemed impractical for inclusion.

```python
class TestPGBaseBackup:
        def test_backup_end_segment_and_time(self, db, pg_version: str):
        conn = db.connect()
        conn.autocommit = True
        cursor = conn.cursor()

        # Force a WAL switch to guarantee that the next LSN is at the start of a new WAL segment
        cursor.execute("SELECT pg_switch_wal();")

        # Generate enough activity to ensure we approach a segment boundary (16 MB)
        cursor.execute("DROP TABLE IF EXISTS wal_test;")
        cursor.execute("CREATE TABLE wal_test (id serial, data text);")
        for _ in range(1024):
            cursor.execute("INSERT INTO wal_test (data) SELECT 'x' || repeat('y', 1024) FROM generate_series(1, 1024);")
        cursor.execute("CHECKPOINT;")
        cursor.execute("SELECT pg_switch_wal();")

        # basic PGBaseBackup, just use backup_end_segment_and_time for noticing discrepancies among versions
        # when LSN falls on a boundary

        pgb = PGBaseBackup(
            config=SIMPLE_BACKUP_CONFIG,
            site="foosite",
            connection_info=None,
            basebackup_path=None,
            compression_queue=None,
            storage=None,
            transfer_queue=None,
            metrics=metrics.Metrics(statsd={}),
            pg_version_server=int(pg_version) * 10000,
        )

        basebackup_name = "test_backup"

        # Manually start and stop backup (could be better, but just need to test basic behavior)
        # pylint: disable=protected-access
        pgb._start_backup(cursor, basebackup_name)
        stop_backup_result = pgb._stop_backup(cursor)

        expected_segment = self._calculate_wal_segment(lsn=stop_backup_result.lsn)

        # for >=PG17 must rely on stop_backup_result LSN, not on current_lsn. For demo this,
        # will change pg_version_server to PG16 and show what will happen if fix in pg_walfile_name is not considered
        if int(pg_version) >= 17:
            pgb.pg_version_server = 160000
            result_end_segment, _ = pgb.get_backup_end_segment_and_time(stop_backup_result, conn)
            assert result_end_segment != expected_segment  # relying on steps for <PG17, is not accurate.

            # set back and test again
            pgb.pg_version_server = int(pg_version) * 10000

        result_end_segment, _ = pgb.get_backup_end_segment_and_time(stop_backup_result, conn)
        assert result_end_segment == expected_segment

    def _calculate_wal_segment(self, lsn: str, timeline: str = "00000001") -> str:
        # Extract XLog ID and Offset from LSN (format: XLogID/Offset)
        xlog_id, xlog_offset = map(lambda x: int(x, 16), lsn.split("/"))

        # Calculate the WAL segment number
        segment_number = (xlog_id << 32 | xlog_offset) // 0x01000000

        # Format the segment number into XLog ID and Offset
        xlog_id_formatted = f"{segment_number >> 32:08X}"
        xlog_offset_formatted = f"{segment_number & 0xFFFFFFFF:08X}"

        return f"{timeline}{xlog_id_formatted}{xlog_offset_formatted}"
```

Resolves: #BF-2568


# UPDATE:

Decided to remove changes in `get_backup_end_segment_and_time` for considering changes in `pg_walfile_name` for PG17,  was discussed offline and we agreed to keep old behavior rather than having two different ways for getting the end segment.
