### PR TITLE
choose basebackup if it exactly matches PITR date

### DIFF
--- a/pghoard/restore.py
+++ b/pghoard/restore.py
@@ -372,7 +372,7 @@ class Restore:
                     backup_ts = dates.parse_timestamp(basebackup["metadata"]["end-time"])
                 else:
                     backup_ts = dates.parse_timestamp(basebackup["metadata"]["start-time"])
-                if backup_ts >= recovery_target_time:
+                if backup_ts > recovery_target_time:
                     continue
             applicable_basebackups.append(basebackup)
 

--- a/test/test_restore.py
+++ b/test/test_restore.py
@@ -103,6 +103,11 @@ class TestRecoveryConf(PGHoardTestCase):
         recovery_time = recovery_time.replace(tzinfo=datetime.timezone.utc)
         assert r._find_nearest_basebackup(recovery_time)["name"] == "2015-02-12_0"  # pylint: disable=protected-access
 
+        # for each basebackup, make sure we find it when asking for its exact time
+        for basebackup in basebackups:
+            recovery_time = datetime.datetime.fromisoformat(basebackup["metadata"]["start-time"])
+            assert r._find_nearest_basebackup(recovery_time)["name"] == basebackup["name"]  # pylint: disable=protected-access
+
     def test_compatible_cli_args(self):
         parser = Restore().create_parser()
 


### PR DESCRIPTION
Update recovery logic to select a basebackup also when its timestamp exactly matches the requested Point-In-Time Recovery (PITR) date.
