### PR TITLE
Stop receivexlog threads when backup mode is basic

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,5 @@
 [mypy]
-python_version = 3.9
 warn_redundant_casts = True
-
 
 [mypy-azure.*]
 ignore_missing_imports = True
@@ -32,4 +30,3 @@ ignore_missing_imports = True
 
 [mypy-systemd.*]
 ignore_missing_imports = True
-

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -726,6 +726,11 @@ class PGHoard:
         if not site_config["active"]:
             return  # If a site has been marked inactive, don't bother checking anything
 
+        # Stop any existing receivexlog threads if we're in basic mode
+        if site_config["active_backup_mode"] == "basic":
+            for t in self.receivexlogs.values():
+                t.running = False
+
         self._cleanup_inactive_receivexlogs(site)
 
         chosen_backup_node = random.choice(site_config["nodes"])


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Stop receivexlog threads when backup mode is set to `basic` to allow the respective replication slot to be cleaned.