### PR TITLE
Multiple site migration cleanup

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -28,7 +28,7 @@ disable=
 
 [FORMAT]
 max-line-length=125
-max-module-lines=1200
+max-module-lines=1300
 
 [REPORTS]
 output-format=text

--- a/pghoard/object_store.py
+++ b/pghoard/object_store.py
@@ -7,7 +7,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from requests import Session
 from requests.auth import HTTPBasicAuth
@@ -17,14 +17,14 @@ from pghoard import common
 
 
 class BaseBackupInfo:
-    def __init__(self, name: str, site: str, data: dict[str, Any]):
+    def __init__(self, name: str, site: str, data: Dict[str, Any]):
         self.name = name
         self.data = data
         self.site = site
 
 
 class BaseBackupInfoFromBucket(BaseBackupInfo):
-    def __init__(self, name: str, site: str, prefix: str, storage: BaseTransfer[Any], data: dict[str, Any]):
+    def __init__(self, name: str, site: str, prefix: str, storage: BaseTransfer[Any], data: Dict[str, Any]):
         super().__init__(data=data, name=name, site=site)
         self.storage = storage
         self.prefix = prefix

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -406,7 +406,7 @@ class PGHoard:
         delta_backup_names = {
             backup.name: backup.data["metadata"]
             for backup in backups_to_keep
-            if backup.data["metadata"]["format"] in delta_formats
+            if backup.data["metadata"]["format"] in delta_formats and backup.site == site
         }
         delta_backup_names[basebackup_name_to_delete] = metadata
 
@@ -635,11 +635,13 @@ class PGHoard:
                 bb_tbd_site,
                 basebackup_to_be_deleted.name,
                 basebackup_to_be_deleted.data["metadata"],
-                basebackups=chained_basebackups
+                # just provide backups from the basebackup_to_be_deleted's site
+                basebackups=[cb for cb in chained_basebackups if cb.site == bb_tbd_site],
             )
 
         all_chained_sites = [site] + site_config.get("moved_from", [])
         for c_site in all_chained_sites:
+            self.set_state_defaults(c_site)
             self.state["backup_sites"][c_site]["basebackups"] = [bb.data for bb in chained_basebackups if bb.site == c_site]
 
     def get_normalized_backup_time(self, site_config, *, now=None):

--- a/test/base.py
+++ b/test/base.py
@@ -64,7 +64,7 @@ class PGHoardTestCase:
 
         # Instantiate a fake PG data directory
         pg_data_directory = os.path.join(str(self.temp_dir), "PG_DATA_DIRECTORY")
-        os.makedirs(pg_data_directory)
+        os.makedirs(pg_data_directory, exist_ok=True)
         open(os.path.join(pg_data_directory, "PG_VERSION"), "w").write(ver)
 
         config = {
@@ -93,6 +93,8 @@ class PGHoardTestCase:
                     config["backup_sites"][site_name].update(site_override)
                 else:
                     config["backup_sites"][site_name] = site_override
+
+                config["backup_sites"][site_name]["pg_data_directory"] = pg_data_directory
             config.update(override)
 
         os.makedirs(config["alert_file_dir"], exist_ok=True)

--- a/test/basebackup/test_delta.py
+++ b/test/basebackup/test_delta.py
@@ -18,6 +18,7 @@ from pghoard.basebackup.chunks import ChunkUploader, HashFile
 from pghoard.basebackup.delta import DeltaBaseBackup, UploadedFilesMetric
 from pghoard.common import (BackupFailure, BaseBackupFormat, CallbackEvent, CallbackQueue, CompressionData, EncryptionData)
 from pghoard.metrics import Metrics
+from pghoard.object_store import BaseBackupInfo
 from pghoard.transfer import TransferQueue
 
 
@@ -175,33 +176,47 @@ def test_list_existing_files_skips_non_delta_formats(deltabasebackup: DeltaBaseB
     with patch.object(deltabasebackup, "get_remote_basebackups_info") as mock_get_remote_basebackups_info, \
             patch("pghoard.basebackup.delta.download_backup_meta_file", new=fake_download_backup_meta):
         mock_get_remote_basebackups_info.return_value = [
-            {
-                "metadata": {
+            BaseBackupInfo(
+                name="",
+                site=deltabasebackup.site,
+                data={"metadata": {
                     "format": BaseBackupFormat.v1
-                }
-            },
-            {
-                "metadata": {
+                }},
+            ),
+            BaseBackupInfo(
+                name="",
+                site=deltabasebackup.site,
+                data={"metadata": {
                     "format": BaseBackupFormat.v2
-                }
-            },
-            {
-                "metadata": {
-                    "format": BaseBackupFormat.delta_v1
+                }},
+            ),
+            BaseBackupInfo(
+                name="delta_v1",
+                site=deltabasebackup.site,
+                data={
+                    "metadata": {
+                        "format": BaseBackupFormat.delta_v1
+                    },
+                    "name": "delta_v1"
                 },
-                "name": "delta_v1"
-            },
-            {
-                "metadata": {
-                    "format": BaseBackupFormat.delta_v2
+            ),
+            BaseBackupInfo(
+                name="delta_v2",
+                site=deltabasebackup.site,
+                data={
+                    "metadata": {
+                        "format": BaseBackupFormat.delta_v2
+                    },
+                    "name": "delta_v2"
                 },
-                "name": "delta_v2"
-            },
-            {
-                "metadata": {
+            ),
+            BaseBackupInfo(
+                name="basebackup_4",
+                site=deltabasebackup.site,
+                data={"metadata": {
                     "format": "unknown"
-                }
-            },
+                }},
+            ),
         ]
         assert deltabasebackup._list_existing_files() == {  # pylint: disable=protected-access
             "delta1hex1": SnapshotFile(

--- a/test/test_pghoard.py
+++ b/test/test_pghoard.py
@@ -710,7 +710,7 @@ dbname|"""
             wal_storage_path=os.path.join(_get_site_dir(self.test_site), "xlog"),
             backups_and_wals={
                 "2026-02-11_2": ["000000010000000A00000000A", "000000010000000A0000000B"],
-                "2026-02-11_3": ["000000010000000A00000000A", "000000010000000A0000000B"],
+                "2026-02-11_3": ["000000010000000A00000000C", "000000010000000A0000000D"],
             },
         )
         self.pghoard.refresh_backup_list_and_delete_old(self.test_site)


### PR DESCRIPTION
PR introduces required changes for purging WALs and basebackups from previous sites. New mechanism considers a chain of backups based on the new 'moved_from' setting. When applying expiration settings for an ACTIVE site, backups from any sites listed in 'moved_from' are also considered. All backups in the chain will follow the expiration settings of the active site. Based on these rules, pghoard will delete backups from their corresponding site if they meet the expiration criteria.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

