### PR TITLE
Fix pghoard hanging on critical compression failure

### DIFF
--- a/pghoard/compressor.py
+++ b/pghoard/compressor.py
@@ -222,7 +222,16 @@ class CompressorThread(PGHoardThread):
             )
 
             if compressed_filepath:
-                os.link(output_obj.name, compressed_filepath)
+                try:
+                    os.link(output_obj.name, compressed_filepath)
+                except FileExistsError:
+                    # This can happen if the same file is received multiple times (e.g., pg_receivewal
+                    # reconnecting and re-sending timeline files). The compressed file already exists
+                    # but may not have been uploaded yet. Re-queue the event to retry later once the
+                    # existing compressed file has been uploaded and deleted.
+                    self.log.info("Compressed file %s already exists, re-queuing event for later retry", compressed_filepath)
+                    self.compression_queue.put(event)
+                    return True
             else:
                 output_data = BytesIO(output_obj.getvalue())
 

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -1157,7 +1157,7 @@ class PGHoard:
         )
         self.quit()
 
-    def quit(self):
+    def quit(self, join_timeout: float = 10.0):
         self.running = False
         self.inotify.running = False
         all_threads = self._get_all_threads()
@@ -1167,7 +1167,8 @@ class PGHoard:
         self.write_backup_state_to_json_file()
         for t in all_threads:
             if t.is_alive():
-                t.join()
+                t.join(timeout=join_timeout)
+
         if self.mp_manager:
             self.mp_manager.shutdown()
             self.mp_manager = None


### PR DESCRIPTION
When a compression thread encountered a FileExistsError (e.g., due to pg_receivewal reconnecting and re-sending timeline files), it would trigger a critical failure after 3 retries. The subsequent quit() call might hang indefinitely because t.join() was called without a timeout.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

