### PR TITLE
Cancel stuck pg_backup_start query on SIGTERM

### DIFF
--- a/pghoard/basebackup/base.py
+++ b/pghoard/basebackup/base.py
@@ -85,6 +85,7 @@ class PGBaseBackup(PGHoardThread):
         self.metrics = metrics
         self.transfer_queue = transfer_queue
         self.running = True
+        self._db_conn: Optional[psycopg2.extensions.connection] = None
         self.pid = None
         self.pg_version_server = pg_version_server
         self.latest_activity = datetime.datetime.utcnow()
@@ -101,6 +102,16 @@ class PGBaseBackup(PGHoardThread):
             is_running=lambda: self.running,
             transfer_queue=transfer_queue
         )
+
+    def cancel(self) -> None:
+        self.running = False
+        db_conn = self._db_conn
+        if db_conn is not None:
+            try:
+                db_conn.cancel()
+                self.log.info("Cancelled active database query due to shutdown")
+            except Exception as e:  # pylint: disable=broad-except
+                self.log.warning("Failed to cancel database query: %s", e)
 
     def run_safe(self):
         try:
@@ -547,6 +558,7 @@ class PGBaseBackup(PGHoardThread):
         self.log.debug("Connecting to database to start backup process")
         connection_string = connection_string_using_pgpass(self.connection_info)
         with psycopg2.connect(connection_string) as db_conn:
+            self._db_conn = db_conn
             conn_polling = lambda: check_if_pg_connection_is_alive(db_conn)
             cursor = db_conn.cursor()
 
@@ -695,6 +707,7 @@ class PGBaseBackup(PGHoardThread):
                 progress_instance.reset_all(metrics=self.metrics)
 
             finally:
+                self._db_conn = None
                 db_conn.rollback()
                 if not backup_stopped:
                     self._stop_backup(cursor)

--- a/pghoard/pghoard.py
+++ b/pghoard/pghoard.py
@@ -1139,6 +1139,8 @@ class PGHoard:
         """
         self.log.info("Gracefully shutting down...")
         self.running = False
+        for basebackup_thread in self.basebackups.values():
+            basebackup_thread.cancel()
         for thread in [*self.receivexlogs.values(), *self.walreceivers.values()]:
             thread.running = False
             thread.join(timeout=10)
@@ -1163,6 +1165,8 @@ class PGHoard:
         all_threads = self._get_all_threads()
         for t in all_threads:
             t.running = False
+        for basebackup_thread in self.basebackups.values():
+            basebackup_thread.cancel()
         # Write state file in the end so we get the last known state
         self.write_backup_state_to_json_file()
         for t in all_threads:

--- a/test/basebackup/test_basebackup.py
+++ b/test/basebackup/test_basebackup.py
@@ -92,6 +92,69 @@ LABEL: pg_basebackup base backup
         assert start_wal_segment == "000000010000000000000004"
         assert start_time == "2015-02-12T14:07:19+00:00"
 
+    def test_cancel_stops_running_and_cancels_connection(self):
+        pgb = _get_simple_pg_base_backup()
+        mock_conn = MagicMock()
+        pgb._db_conn = mock_conn  # pylint: disable=protected-access
+
+        pgb.cancel()
+
+        assert pgb.running is False
+        mock_conn.cancel.assert_called_once()
+
+    def test_cancel_without_active_connection(self):
+        pgb = _get_simple_pg_base_backup()
+        assert pgb._db_conn is None  # pylint: disable=protected-access
+
+        pgb.cancel()
+
+        assert pgb.running is False
+
+    def test_cancel_tolerates_connection_error(self):
+        pgb = _get_simple_pg_base_backup()
+        mock_conn = MagicMock()
+        mock_conn.cancel.side_effect = psycopg2.InterfaceError("connection already closed")
+        pgb._db_conn = mock_conn  # pylint: disable=protected-access
+
+        pgb.cancel()
+
+        assert pgb.running is False
+        mock_conn.cancel.assert_called_once()
+
+    def test_cancel_interrupts_stuck_start_backup(self):
+        import threading
+
+        pgb = _get_simple_pg_base_backup()
+        mock_conn = MagicMock()
+        query_started = threading.Event()
+        query_cancelled = threading.Event()
+
+        def blocking_execute(_query, *_args):
+            query_started.set()
+            query_cancelled.wait(timeout=5)
+            raise psycopg2.extensions.QueryCanceledError("canceling statement due to user request")
+
+        mock_cursor = MagicMock()
+        mock_cursor.execute.side_effect = blocking_execute
+        mock_conn.cursor.return_value = mock_cursor
+        mock_conn.cancel.side_effect = query_cancelled.set
+
+        pgb._db_conn = mock_conn  # pylint: disable=protected-access
+
+        def run_start_backup():
+            with pytest.raises(psycopg2.extensions.QueryCanceledError):
+                pgb._start_backup(mock_cursor, "test_backup")  # pylint: disable=protected-access
+
+        backup_thread = threading.Thread(target=run_start_backup)
+        backup_thread.start()
+
+        query_started.wait(timeout=5)
+        pgb.cancel()
+
+        backup_thread.join(timeout=5)
+        assert not backup_thread.is_alive()
+        assert pgb.running is False
+
     def test_find_files(self, db):
         top1 = os.path.join(db.pgdata, "top1.test")
         top2 = os.path.join(db.pgdata, "top2.test")


### PR DESCRIPTION
When pg_backup_start hangs (e.g. due to a stuck checkpoint), pghoard
refuses to stop because the blocking cursor.execute() call is not
interrupted by setting running=False.

Add a cancel() method to PGBaseBackup that calconnection.cancel(),
which sends a cancel signal to PG backend.

Invoke it from both graceful_shutdown() and quit() paths.

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

